### PR TITLE
Test API for targeted lowering tests

### DIFF
--- a/tests/api/meson.build
+++ b/tests/api/meson.build
@@ -1,0 +1,11 @@
+test_api_files = files([
+  'test_api.cpp',
+  'test_api_io.cpp',
+])
+
+lib_dxbc_spv_test_api = static_library('test_api', test_api_files,
+  link_with   : [ lib_dxbc_spv ])
+
+executable('test_api_dump', files([ 'test_api_dump.cpp']),
+  link_with   : [ lib_dxbc_spv_test_api, lib_dxbc_spv ],
+  install     : false)

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -1,0 +1,35 @@
+#include "test_api.h"
+#include "test_api_io.h"
+
+namespace dxbc_spv::test_api {
+
+using GetTestPfn = ir::Builder (*)();
+
+void addTest(std::vector<NamedTest>& tests, const char* filter,
+    const char* name, GetTestPfn fn) {
+  if (filter && !std::strstr(name, filter))
+    return;
+
+  auto& test = tests.emplace_back();
+  test.name = name;
+  test.builder = fn();
+}
+
+std::vector<NamedTest> enumerateTests(const char* filter) {
+#define ADD_TEST(test) addTest(result, filter, #test, &test)
+  std::vector<NamedTest> result;
+
+  ADD_TEST(test_io_vs);
+  ADD_TEST(test_io_vs_vertex_id);
+  ADD_TEST(test_io_vs_instance_id);
+  ADD_TEST(test_io_vs_clip_dist);
+  ADD_TEST(test_io_vs_cull_dist);
+  ADD_TEST(test_io_vs_clip_cull_dist);
+  ADD_TEST(test_io_vs_layer);
+  ADD_TEST(test_io_vs_viewport);
+
+  return result;
+#undef ADD_TEST
+}
+
+}

--- a/tests/api/test_api.h
+++ b/tests/api/test_api.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "../../ir/ir_builder.h"
+
+namespace dxbc_spv::test_api {
+
+/** Test entry */
+struct NamedTest {
+  std::string name;
+  ir::Builder builder;
+};
+
+/** Retrieves available lowering tests. The filter is optional and
+ *  may be used to retrieve only a subset of the named tests. */
+std::vector<NamedTest> enumerateTests(const char* filter);
+
+}

--- a/tests/api/test_api_common.h
+++ b/tests/api/test_api_common.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../../ir/ir_builder.h"
+
+namespace dxbc_spv::test_api {
+
+using namespace dxbc_spv::ir;
+
+inline SsaDef setupTestFunction(Builder& builder, ShaderStage stage) {
+  SsaDef defFuncA = builder.add(Op::Function(Type()));
+  builder.add(Op::FunctionEnd());
+
+  SsaDef defFuncB;
+  SsaDef entryPoint;
+
+  if (stage == ShaderStage::eHull) {
+    defFuncB = builder.add(Op::Function(Type()));
+    builder.add(Op::FunctionEnd());
+
+    entryPoint = builder.add(Op::EntryPoint(defFuncA, defFuncB, stage));
+
+    builder.add(Op::DebugName(defFuncA, "control_point"));
+    builder.add(Op::DebugName(defFuncB, "patch_constant"));
+  } else {
+    entryPoint = builder.add(Op::EntryPoint(defFuncA, stage));
+    builder.add(Op::DebugName(defFuncA, "main"));
+  }
+
+  builder.setCursor(defFuncA);
+
+  return entryPoint;
+}
+
+}

--- a/tests/api/test_api_dump.cpp
+++ b/tests/api/test_api_dump.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+
+#include "test_api.h"
+
+#include "../../ir/ir_disasm.h"
+
+int main(int argc, char** argv) {
+  const char* filter = nullptr;
+
+  if (argc > 1)
+    filter = argv[1u];
+
+  auto tests = dxbc_spv::test_api::enumerateTests(filter);
+
+  for (const auto& test : tests) {
+    std::cout << test.name << ":" << std::endl;
+
+    dxbc_spv::ir::Disassembler disasm(test.builder, dxbc_spv::ir::Disassembler::Options());
+    disasm.disassemble(std::cout);
+
+    std::cout << std::endl;
+  }
+}

--- a/tests/api/test_api_io.cpp
+++ b/tests/api/test_api_io.cpp
@@ -1,0 +1,227 @@
+#include "test_api_io.h"
+
+namespace dxbc_spv::test_api {
+
+Builder test_io_vs() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto posInDef = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(posInDef, 0u, "POSITION"));
+  builder.add(Op::DebugName(posInDef, "v0"));
+
+  auto normalInDef = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u));
+  builder.add(Op::Semantic(normalInDef, 0u, "NORMAL"));
+  builder.add(Op::DebugName(normalInDef, "v1"));
+
+  auto tangent0InDef = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 2u, 0u));
+  builder.add(Op::Semantic(tangent0InDef, 0u, "TANGENT"));
+  builder.add(Op::DebugName(tangent0InDef, "v2"));
+
+  auto tangent1InDef = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 3u, 0u));
+  builder.add(Op::Semantic(tangent1InDef, 1u, "TANGENT"));
+  builder.add(Op::DebugName(tangent1InDef, "v3"));
+
+  auto colorInDef = builder.add(Op::DclInput(BasicType(ScalarType::eU32, 1u), entryPoint, 4u, 0u));
+  builder.add(Op::Semantic(colorInDef, 1u, "COLOR"));
+  builder.add(Op::DebugName(colorInDef, "v4"));
+
+  auto posOutDef = builder.add(Op::DclOutputBuiltIn(BasicType(ScalarType::eF32, 4u), entryPoint, BuiltIn::ePosition));
+  builder.add(Op::Semantic(posOutDef, 0u, "SV_POSITION"));
+  builder.add(Op::DebugName(posOutDef, "o0"));
+
+  auto normalOutDef = builder.add(Op::DclOutput(BasicType(ScalarType::eF32, 4u), entryPoint, 1u, 0u));
+  builder.add(Op::Semantic(normalOutDef, 0u, "NORMAL"));
+  builder.add(Op::DebugName(normalOutDef, "o1_xyz"));
+
+  auto colorOutDef = builder.add(Op::DclOutput(ScalarType::eU32, entryPoint, 1u, 3u));
+  builder.add(Op::Semantic(colorOutDef, 0u, "COLOR"));
+  builder.add(Op::DebugName(colorOutDef, "o1_w"));
+
+  auto tangent0OutDef = builder.add(Op::DclOutput(ScalarType::eU32, entryPoint, 2u, 0u));
+  builder.add(Op::Semantic(tangent0OutDef, 0u, "TANGENT"));
+  builder.add(Op::DebugName(tangent0OutDef, "o2"));
+
+  auto tangent1OutDef = builder.add(Op::DclOutput(ScalarType::eU32, entryPoint, 3u, 0u));
+  builder.add(Op::Semantic(tangent1OutDef, 1u, "TANGENT"));
+  builder.add(Op::DebugName(tangent1OutDef, "o3"));
+
+  builder.add(Op::OutputStore(posOutDef, SsaDef(),
+    builder.add(Op::CompositeConstruct(BasicType(ScalarType::eF32, 4u),
+      builder.add(Op::InputLoad(ScalarType::eF32, posInDef, builder.makeConstant(0u))),
+      builder.add(Op::InputLoad(ScalarType::eF32, posInDef, builder.makeConstant(1u))),
+      builder.add(Op::InputLoad(ScalarType::eF32, posInDef, builder.makeConstant(2u))),
+      builder.makeConstant(1.0f)))));
+
+  builder.add(Op::OutputStore(normalOutDef, SsaDef(),
+    builder.add(Op::InputLoad(BasicType(ScalarType::eF32, 3u), normalInDef, SsaDef()))));
+
+  builder.add(Op::OutputStore(colorOutDef, SsaDef(),
+    builder.add(Op::InputLoad(ScalarType::eU32, colorInDef, SsaDef()))));
+
+  auto tangent0 = builder.add(Op::InputLoad(BasicType(ScalarType::eF32, 3u), tangent0InDef, SsaDef()));
+
+  for (uint32_t i = 0u; i < 3u; i++) {
+    builder.add(Op::OutputStore(tangent0OutDef, builder.makeConstant(i),
+      builder.add(Op::CompositeExtract(ScalarType::eF32, tangent0, builder.makeConstant(i)))));
+  }
+
+  for (uint32_t i = 0u; i < 3u; i++) {
+    builder.add(Op::OutputStore(tangent1OutDef, builder.makeConstant(i),
+      builder.add(Op::InputLoad(ScalarType::eF32, tangent1InDef, builder.makeConstant(i)))));
+  }
+
+  builder.add(Op::Return());
+
+  return builder;
+}
+
+Builder test_io_vs_vertex_id() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto inDef = builder.add(Op::DclInputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eVertexId));
+  builder.add(Op::Semantic(inDef, 0u, "SV_VERTEXID"));
+  builder.add(Op::DebugName(inDef, "v0"));
+
+  auto outDef = builder.add(Op::DclOutput(ScalarType::eU32, entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(outDef, 0u, "SHADER_OUT"));
+  builder.add(Op::DebugName(outDef, "o0"));
+
+  builder.add(Op::OutputStore(outDef, SsaDef(),
+    builder.add(Op::InputLoad(ScalarType::eU32, inDef, SsaDef()))));
+
+  return builder;
+}
+
+Builder test_io_vs_instance_id() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto inDef = builder.add(Op::DclInputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eInstanceId));
+  builder.add(Op::Semantic(inDef, 0u, "SV_INSTANCEID"));
+  builder.add(Op::DebugName(inDef, "v0"));
+
+  auto outDef = builder.add(Op::DclOutput(ScalarType::eU32, entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(outDef, 0u, "SHADER_OUT"));
+  builder.add(Op::DebugName(outDef, "o0"));
+
+  builder.add(Op::OutputStore(outDef, SsaDef(),
+    builder.add(Op::InputLoad(ScalarType::eU32, inDef, SsaDef()))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_vs_clip_dist() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto outDef = builder.add(Op::DclOutputBuiltIn(
+    Type(ScalarType::eF32).addArrayDimension(6u), entryPoint, BuiltIn::eClipDistance));
+  builder.add(Op::Semantic(outDef, 0u, "SV_CLIPDISTANCE"));
+  builder.add(Op::DebugName(outDef, "oClip"));
+
+  for (uint32_t i = 0u; i < 6u; i++) {
+    builder.add(Op::OutputStore(outDef, builder.makeConstant(i),
+      builder.makeConstant(float(i) - 2.5f)));
+  }
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_vs_cull_dist() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto outDef = builder.add(Op::DclOutputBuiltIn(
+    Type(ScalarType::eF32).addArrayDimension(2u), entryPoint, BuiltIn::eCullDistance));
+  builder.add(Op::Semantic(outDef, 0u, "SV_CULLDISTANCE"));
+  builder.add(Op::DebugName(outDef, "oCull"));
+
+  builder.add(Op::OutputStore(outDef, builder.makeConstant(0u), builder.makeConstant(0.7f)));
+  builder.add(Op::OutputStore(outDef, builder.makeConstant(1u), builder.makeConstant(0.1f)));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_vs_clip_cull_dist() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto clipDef = builder.add(Op::DclOutputBuiltIn(
+    Type(ScalarType::eF32).addArrayDimension(7u), entryPoint, BuiltIn::eClipDistance));
+  builder.add(Op::Semantic(clipDef, 0u, "SV_CLIPDISTANCE"));
+  builder.add(Op::DebugName(clipDef, "oClip"));
+
+  auto cullDef = builder.add(Op::DclOutputBuiltIn(
+    Type(ScalarType::eF32).addArrayDimension(1u), entryPoint, BuiltIn::eCullDistance));
+  builder.add(Op::Semantic(cullDef, 0u, "SV_CULLDISTANCE"));
+  builder.add(Op::DebugName(cullDef, "oCull"));
+
+  for (uint32_t i = 0u; i < 7u; i++)
+    builder.add(Op::OutputStore(clipDef, builder.makeConstant(i), builder.makeConstant(float(i) - 2.5f)));
+
+  builder.add(Op::OutputStore(cullDef, builder.makeConstant(0u), builder.makeConstant(-2.0f)));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_vs_layer() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto inDef = builder.add(Op::DclInputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eInstanceId));
+  builder.add(Op::Semantic(inDef, 0u, "SV_INSTANCEID"));
+  builder.add(Op::DebugName(inDef, "v0"));
+
+  auto outDef = builder.add(Op::DclOutputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eLayerIndex));
+  builder.add(Op::Semantic(outDef, 0u, "SV_RenderTargetArrayIndex"));
+  builder.add(Op::DebugName(outDef, "o0"));
+
+  builder.add(Op::OutputStore(outDef, SsaDef(),
+    builder.add(Op::InputLoad(ScalarType::eU32, inDef, SsaDef()))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_vs_viewport() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eVertex);
+
+  builder.add(Op::Label());
+
+  auto inDef = builder.add(Op::DclInputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eInstanceId));
+  builder.add(Op::Semantic(inDef, 0u, "SV_INSTANCEID"));
+  builder.add(Op::DebugName(inDef, "v0"));
+
+  auto outDef = builder.add(Op::DclOutputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eViewportIndex));
+  builder.add(Op::Semantic(outDef, 0u, "SV_ViewportArrayIndex"));
+  builder.add(Op::DebugName(outDef, "o0"));
+
+  builder.add(Op::OutputStore(outDef, SsaDef(),
+    builder.add(Op::InputLoad(ScalarType::eU32, inDef, SsaDef()))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+}

--- a/tests/api/test_api_io.h
+++ b/tests/api/test_api_io.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "test_api_common.h"
+
+namespace dxbc_spv::test_api {
+
+Builder test_io_vs();
+Builder test_io_vs_vertex_id();
+Builder test_io_vs_instance_id();
+Builder test_io_vs_clip_dist();
+Builder test_io_vs_cull_dist();
+Builder test_io_vs_clip_cull_dist();
+Builder test_io_vs_layer();
+Builder test_io_vs_viewport();
+
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,3 +13,5 @@ test_files = files([
 executable('test_dxbc_spv', test_files,
   link_with   : [ lib_dxbc_spv ],
   install     : false)
+
+subdir('api')


### PR DESCRIPTION
Adds a static library that spits out a list of named tests. Includes some basic vertex shader I/O tests for now, needs feedback on whether this direction is good though.

@HansKristian-Work