### PR TITLE
Initial SPIR-V builder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/spirv_headers"]
+	path = submodules/spirv_headers
+	url = https://github.com/KhronosGroup/SPIRV-Headers.git

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -248,6 +248,14 @@ uint32_t Op::getFirstLiteralOperandIndex() const {
     case OpCode::eFRound:
       return 1u;
 
+    case OpCode::eBufferLoad:
+    case OpCode::eMemoryLoad:
+      return 2u;
+
+    case OpCode::eBufferStore:
+    case OpCode::eMemoryStore:
+      return 3u;
+
     case OpCode::eEntryPoint:
     case OpCode::eLabel:
     case OpCode::eLdsAtomic:

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -1823,17 +1823,19 @@ public:
       .addOperand(Operand(index));
   }
 
-  static Op BufferLoad(Type type, SsaDef descriptor, SsaDef address) {
+  static Op BufferLoad(Type type, SsaDef descriptor, SsaDef address, uint32_t alignment) {
     return Op(OpCode::eBufferLoad, type)
       .addOperand(Operand(descriptor))
-      .addOperand(Operand(address));
+      .addOperand(Operand(address))
+      .addOperand(Operand(alignment));
   }
 
-  static Op BufferStore(SsaDef descriptor, SsaDef address, SsaDef value) {
+  static Op BufferStore(SsaDef descriptor, SsaDef address, SsaDef value, uint32_t alignment) {
     return Op(OpCode::eBufferStore, Type())
       .addOperand(Operand(descriptor))
       .addOperand(Operand(address))
-      .addOperand(Operand(value));
+      .addOperand(Operand(value))
+      .addOperand(Operand(alignment));
   }
 
   static Op BufferQuerySize(SsaDef descriptor) {
@@ -1841,17 +1843,19 @@ public:
       .addOperand(Operand(descriptor));
   }
 
-  static Op MemoryLoad(Type type, SsaDef pointer, SsaDef address) {
+  static Op MemoryLoad(Type type, SsaDef pointer, SsaDef address, uint32_t alignment) {
     return Op(OpCode::eMemoryLoad, type)
       .addOperand(Operand(pointer))
-      .addOperand(Operand(address));
+      .addOperand(Operand(address))
+      .addOperand(Operand(alignment));
   }
 
-  static Op MemoryStore(SsaDef pointer, SsaDef address, SsaDef value) {
+  static Op MemoryStore(SsaDef pointer, SsaDef address, SsaDef value, uint32_t alignment) {
     return Op(OpCode::eMemoryStore, Type())
       .addOperand(Operand(pointer))
       .addOperand(Operand(address))
-      .addOperand(Operand(value));
+      .addOperand(Operand(value))
+      .addOperand(Operand(alignment));
   }
 
   template<typename... T>

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -112,7 +112,7 @@ Semantics are as follows:
 - `ConvertFToI` is a saturating conversion from a float type to a signed or unsigned integer, with round-to-zero semantics.
 - `ConvertIToF` is a value-preserving conversion from a signed or unsigned integer to any float type with round-even semantics.
 - `ConvertItoI` converts between integer types of different size. If the result type is larger than the source and the source
-  is signed, it will be sign-extended, otherwise it will be sign-extended. If the result type is smaller, excess bits are discarded.
+  is signed, it will be sign-extended, otherwise it will be zero-extended. If the result type is smaller, excess bits are discarded.
   If the two types only differ in signedness, this instruction is identical in behaviour to `Cast` and will be lowered to it.
 - `Cast` is a bit-pattern preserving cast between different types that must have the same bit size. Vector types are allowed.
 

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -293,9 +293,14 @@ The `ir::AtomicOp` parameter is a literal enum value, thus the last parameter.
 
 The `%layer` parameter is `null` for non-arrayed image types.
 
-For `ir::AtomicOp::CompareExchange`, the first operand contains the desired value to compare
-to, and the second operand will be the value to store if the comparison succeeds. The operation
-returns the value at the given memory location before any exchange can take place.
+#### Operations
+- `Load`: Atomically loads a value. This instruction is generated when an atomic instruction has
+  no side effects. Must not have a `void` return type.
+- `Store`: Atomically stores a value. This instruction is generated when the result of an atomic
+  exchange instruction goes unused.
+- `Inc` and `Dec` are equivalent to `Add` or `Sub` with a constant value of `1`, respectively.
+- `CompareExchange` has two operands: The value to compare to first, and the value to store on
+  success second.
 
 ### Image instructions
 | `ir::OpCode`         | Return type      | Arguments...  |                   |             |              |              |             |              |          |           |       |             |
@@ -533,9 +538,9 @@ Note that the `FindMsb` instructions follow SPIR-V semantics rather than D3D sem
 | `ir::OpCode`              | Return type  | Arguments... |           |           |
 |---------------------------|--------------|--------------|-----------|-----------|
 | `IAdd`                    | integer      | `%a`         | `%b`      |           |
-| `IAddCarry`               | `vec2<i*/u*>`| `%a`         | `%b`      |           |
+| `IAddCarry`               | `vec2<u*>`   | `%a`         | `%b`      |           |
 | `ISub`                    | integer      | `%a`         | `%b`      |           |
-| `ISubBorrow`              | `vec2<i*/u*>`| `%a`         | `%b`      |           |
+| `ISubBorrow`              | `vec2<u*>`   | `%a`         | `%b`      |           |
 | `INeg`                    | integer      | `%a`         |           |           |
 | `IMul`                    | integer      | `%a`         | `%b`      |           |
 | `SDiv`                    | integer      | `%a`         | `%b`      |           |

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -518,9 +518,9 @@ The `*Legacy` instructions follow D3D9 rules w.r.t. multiplication.
 | `IBitInsert`              | integer      | `%base`      | `%insert` | `%offset` | `%count` |
 | `UBitExtract`             | integer      | `%value`     | `%offset` | `%count`  |          |
 | `SBitExtract`             | integer      | `%value`     | `%offset` | `%count`  |          |
-| `IShl`                    | integer      | `%base`      | `%insert` | `%offset` | `%count` |
-| `SShr`                    | integer      | `%value`     | `%offset` | `%count`  |          |
-| `UShr`                    | integer      | `%value`     | `%offset` | `%count`  |          |
+| `IShl`                    | integer      | `%value`     | `%count`  |           |          |
+| `SShr`                    | integer      | `%value`     | `%count`  |           |          |
+| `UShr`                    | integer      | `%value`     | `%count`  |           |          |
 | `IBitCount`               | integer      | `%value`     |           |           |          |
 | `IBitReverse`             | integer      | `%value`     |           |           |          |
 | `IFindLsb`                | integer      | `%value`     |           |           |          |

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -231,26 +231,26 @@ value around and feed it back into a shader later, or potentially use it in exte
 | `CheckSparseAccess`  | `bool`      | `%feedback`  |
 
 ### Load/Store instructions
-| `ir::OpCode`         | Return type  | Arguments...       |                                |          |
-|----------------------|--------------|--------------------|--------------------------------|----------|
-| `ParamLoad`          | any          | `%Function`        | `%DclParam` ...                |          |
-| `TmpLoad`            | any          | `%DclTmp` variable |                                |          |
-| `TmpStore`           | `void`       | `%DclTmp` variable | `%value`                       |          |
-| `ScratchLoad`        | any          | `%DclScratch` var. | `%address` into scratch array  |          |
-| `ScratchStore`       | `void`       | `%DclScratch` var. | `%address` into scratch array  | `%value` |
-| `LdsLoad`            | any          | `%DclLds` variable | `%address` into LDS            |          |
-| `LdsStore`           | `void`       | `%DclLds` variable | `%address` into LDS            | `%value` |
-| `PushDataLoad`       | any          | `%DclPushData`     | `%address` into push data      |          |
-| `SpecConstantLoad`   | any          | `%DclSpecConstant` | `%address` into spec constant  |          |
-| `InputLoad`          | any          | `%DclInput*`       | `%address` into input type     |          |
-| `OutputLoad`         | any          | `%DclOutput*`      | `%address` into output type    |          |
-| `OutputStore`        | any          | `%DclOutput*`      | `%address` into output type    | `%value` |
-| `DescriptorLoad`     | descriptor   | `%Dcl*` variable   | `%index` into descriptor array |          |
-| `BufferLoad`         | any          | `%descriptor`      | `%address` into CBV / SRV / UAV|          |
-| `BufferStore`        | any          | `%descriptor` (UAV)| `%address` into UAV            | `%value` |
-| `BufferQuerySize`    | `u32`        | `%descriptor`      |                                |          |
-| `MemoryLoad`         | any          | `%Pointer`         | `%address` into pointee type   |          |
-| `MemoryStore`        | any          | `%Pointer`         | `%address` into pointee type   | `%value` |
+| `ir::OpCode`         | Return type  | Arguments...       |                                |          |         |
+|----------------------|--------------|--------------------|--------------------------------|----------|---------|
+| `ParamLoad`          | any          | `%Function`        | `%DclParam` ...                |          |         |
+| `TmpLoad`            | any          | `%DclTmp` variable |                                |          |         |
+| `TmpStore`           | `void`       | `%DclTmp` variable | `%value`                       |          |         |
+| `ScratchLoad`        | any          | `%DclScratch` var. | `%address` into scratch array  |          |         |
+| `ScratchStore`       | `void`       | `%DclScratch` var. | `%address` into scratch array  | `%value` |         |
+| `LdsLoad`            | any          | `%DclLds` variable | `%address` into LDS            |          |         |
+| `LdsStore`           | `void`       | `%DclLds` variable | `%address` into LDS            | `%value` |         |
+| `PushDataLoad`       | any          | `%DclPushData`     | `%address` into push data      |          |         |
+| `SpecConstantLoad`   | any          | `%DclSpecConstant` | `%address` into spec constant  |          |         |
+| `InputLoad`          | any          | `%DclInput*`       | `%address` into input type     |          |         |
+| `OutputLoad`         | any          | `%DclOutput*`      | `%address` into output type    |          |         |
+| `OutputStore`        | any          | `%DclOutput*`      | `%address` into output type    | `%value` |         |
+| `DescriptorLoad`     | descriptor   | `%Dcl*` variable   | `%index` into descriptor array |          |         |
+| `BufferLoad`         | any          | `%descriptor`      | `%address` into CBV / SRV / UAV| `align`  |         |
+| `BufferStore`        | any          | `%descriptor` (UAV)| `%address` into UAV            | `%value` | `align` |
+| `BufferQuerySize`    | `u32`        | `%descriptor`      |                                |          |         |
+| `MemoryLoad`         | any          | `%Pointer`         | `%address` into pointee type   | `align`  |         |
+| `MemoryStore`        | any          | `%Pointer`         | `%address` into pointee type   | `%value` | `align` |
 
 Note that `SrvLoad`, `UavLoad` and `UavStore` instructions can only be used on raw, structured or typed buffer instructions. Image
 resources can only be accessed via image instructions.
@@ -276,6 +276,9 @@ All `TmpLoad` and `TmpStore` instructions will be eliminated during SSA construc
 If the return type for any given `BufferLoad` or `MemoryLoad` instruction is a vector, even though the source type after fully traversing
 `%address` is scalar, then multiple consecutive scalars will be loaded at once. The same goes for `*Store` instructions where `%value` is
 a vector, but the final destination type is scalar. This can allow for more efficient memory access patterns in some cases.
+
+The `align` parameter for `Memory*` and `Buffer` instructions is a literal constant that represents the smallest guaranteed alignment for
+the operation, and will be at least equal to the size of the scalar type being accessed.
 
 ### Atomic instructions
 | `ir::OpCode`         | Return type      | Arguments...      |                              |                |                |                |

--- a/ir/ir_validation.cpp
+++ b/ir/ir_validation.cpp
@@ -355,7 +355,7 @@ bool Validator::validateLoadStoreOps(std::ostream& str) const {
 
     Type dclType = m_builder.getOp(SsaDef(op->getOperand(0u))).getType();
     Type valType = isStore
-      ? m_builder.getOp(SsaDef(op->getOperand(op->getOperandCount() - 1u))).getType()
+      ? m_builder.getOp(SsaDef(op->getOperand(op->getFirstLiteralOperandIndex() - 1u))).getType()
       : op->getType();
 
     Type expectedType = dclType;

--- a/meson.build
+++ b/meson.build
@@ -11,9 +11,12 @@ dxbc_spv_files = files([
   'ir/ir_validation.cpp',
 
   'util/util_float16.cpp',
+
+  'spirv/spirv_builder.cpp',
 ])
 
-lib_dxbc_spv = static_library('dxbc_spv', dxbc_spv_files)
+lib_dxbc_spv = static_library('dxbc_spv', dxbc_spv_files,
+  include_directories : [ 'submodules/spirv_headers/include' ])
 
 if get_option('enable_tests')
   subdir('tests')

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -128,6 +128,9 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
       /* No-op, resolved when declaring function */
       return;
 
+    case ir::OpCode::eDclSampler:
+      return emitDclSampler(op);
+
     case ir::OpCode::eDclCbv:
       return emitDclCbv(op);
 
@@ -277,7 +280,6 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eSetTessDomain:
     case ir::OpCode::eDclSpecConstant:
     case ir::OpCode::eDclPushData:
-    case ir::OpCode::eDclSampler:
     case ir::OpCode::eDclLds:
     case ir::OpCode::eDclScratch:
     case ir::OpCode::eFunctionCall:
@@ -634,6 +636,14 @@ void SpirvBuilder::emitDclBuiltInIoVar(const ir::Op& op) {
   }
 
   addEntryPointId(varId);
+}
+
+
+void SpirvBuilder::emitDclSampler(const ir::Op& op) {
+  auto samplerTypeId = getIdForSamplerType();
+
+  defDescriptor(op, samplerTypeId, spv::StorageClassUniformConstant);
+  m_descriptorTypes.insert({ op.getDef(), samplerTypeId });
 }
 
 
@@ -2396,6 +2406,17 @@ uint32_t SpirvBuilder::getIdForImageType(const SpirvImageTypeKey& key) {
 
   m_imageTypes.insert({ key, id });
   return id;
+}
+
+
+uint32_t SpirvBuilder::getIdForSamplerType() {
+  if (m_samplerTypeId)
+    return m_samplerTypeId;
+
+  m_samplerTypeId = allocId();
+
+  pushOp(m_declarations, spv::OpTypeSampler, m_samplerTypeId);
+  return m_samplerTypeId;
 }
 
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -113,6 +113,9 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eConstant:
       return emitConstant(op);
 
+    case ir::OpCode::eSetCsWorkgroupSize:
+      return emitSetCsWorkgroupSize(op);
+
     case ir::OpCode::eDclInput:
     case ir::OpCode::eDclOutput:
       return emitDclIoVar(op);
@@ -254,7 +257,6 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eUDiv:
       return emitSimpleArithmetic(op);
 
-    case ir::OpCode::eSetCsWorkgroupSize:
     case ir::OpCode::eSetGsInstances:
     case ir::OpCode::eSetGsInputPrimitive:
     case ir::OpCode::eSetGsOutputVertices:
@@ -1982,6 +1984,17 @@ void SpirvBuilder::emitSimpleArithmetic(const ir::Op& op) {
     pushOp(m_declarations, spv::OpDecorate, id, spv::DecorationNoContraction);
 
   emitDebugName(op.getDef(), id);
+}
+
+
+void SpirvBuilder::emitSetCsWorkgroupSize(const ir::Op& op) {
+  auto x = uint32_t(op.getOperand(1u));
+  auto y = uint32_t(op.getOperand(2u));
+  auto z = uint32_t(op.getOperand(3u));
+
+  pushOp(m_executionModes, spv::OpExecutionModeId, m_entryPointId,
+    spv::ExecutionModeLocalSizeId,
+    makeConstU32(x), makeConstU32(y), makeConstU32(z));
 }
 
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -2420,6 +2420,20 @@ uint32_t SpirvBuilder::getIdForSamplerType() {
 }
 
 
+uint32_t SpirvBuilder::getIdForSampledImageType(uint32_t imageTypeId) {
+  auto entry = m_sampledImageTypeIds.find(imageTypeId);
+
+  if (entry != m_sampledImageTypeIds.end())
+    return entry->second;
+
+  uint32_t id = allocId();
+
+  pushOp(m_declarations, spv::OpTypeSampledImage, id, imageTypeId);
+  m_sampledImageTypeIds.insert({ imageTypeId, id });
+  return id;
+}
+
+
 uint32_t SpirvBuilder::getIdForConstant(const SpirvConstant& constant, uint32_t memberCount) {
   auto entry = m_constants.find(constant);
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -1,0 +1,1507 @@
+#include <cstring>
+#include <iostream>
+
+#include "spirv_builder.h"
+
+namespace dxbc_spv::spirv {
+
+SpirvBuilder::SpirvBuilder(const ir::Builder& builder, const Options& options)
+: m_builder(builder), m_options(options) {
+  emitMemoryModel();
+}
+
+
+SpirvBuilder::~SpirvBuilder() {
+
+}
+
+
+void SpirvBuilder::buildSpirvBinary() {
+  if (m_options.includeDebugNames)
+    processDebugNames();
+
+  for (const auto& op : m_builder)
+    emitInstruction(op);
+
+  finalize();
+}
+
+
+std::vector<uint32_t> SpirvBuilder::getSpirvBinary() const {
+  size_t size = 0u;
+  getSpirvBinary(size, nullptr);
+
+  std::vector<uint32_t> binary(size / sizeof(uint32_t));
+  getSpirvBinary(size, binary.data());
+  return binary;
+}
+
+
+void SpirvBuilder::getSpirvBinary(size_t& size, void* data) const {
+  std::array<std::pair<size_t, const uint32_t*>, 10u> arrays = {{
+    { m_capabilities.size(), m_capabilities.data() },
+    { m_extensions.size(), m_extensions.data() },
+    { m_imports.size(), m_imports.data() },
+    { m_memoryModel.size(), m_memoryModel.data() },
+    { m_entryPoint.size(), m_entryPoint.data() },
+    { m_executionModes.size(), m_executionModes.data() },
+    { m_debug.size(), m_debug.data() },
+    { m_decorations.size(), m_decorations.data() },
+    { m_declarations.size(), m_declarations.data() },
+    { m_code.size(), m_code.data() },
+  }};
+
+  /* Compute total required size */
+  size_t dwordCount = sizeof(m_header) / sizeof(uint32_t);
+
+  for (const auto& e : arrays)
+    dwordCount += e.first;
+
+  size_t byteCount = dwordCount * sizeof(uint32_t);
+
+  if (data) {
+    /* Copy as many dwords as we can fit into the buffer */
+    size = std::min(size, byteCount);
+    dwordCount = size / sizeof(uint32_t);
+
+    if (size >= sizeof(m_header))
+      std::memcpy(data, &m_header, sizeof(m_header));
+
+    size_t dwordIndex = sizeof(m_header) / sizeof(uint32_t);
+
+    if (dwordIndex < dwordCount) {
+      for (const auto& e : arrays) {
+        size_t dwordsToCopy = std::min(e.first, dwordCount - dwordIndex);
+        std::memcpy(reinterpret_cast<unsigned char*>(data) + dwordIndex * sizeof(uint32_t),
+          e.second, dwordsToCopy * sizeof(uint32_t));
+
+        dwordIndex += dwordsToCopy;
+      }
+    }
+  } else {
+    /* Write back total byte size */
+    size = byteCount;
+  }
+}
+
+
+void SpirvBuilder::processDebugNames() {
+  auto decls = m_builder.getDeclarations();
+
+  for (auto op = decls.first; op != decls.second; op++) {
+    if (op->getOpCode() == ir::OpCode::eDebugName)
+      m_debugNames.insert({ ir::SsaDef(op->getOperand(0u)), op->getDef() });
+  }
+}
+
+
+void SpirvBuilder::finalize() {
+
+}
+
+
+void SpirvBuilder::emitInstruction(const ir::Op& op) {
+  switch (op.getOpCode()) {
+    case ir::OpCode::eEntryPoint:
+      return emitEntryPoint(op);
+
+    case ir::OpCode::eDebugName:
+    case ir::OpCode::eSemantic:
+      /* No-op here, we resolve debug names early */
+      return;
+
+    case ir::OpCode::eConstant:
+      return emitConstant(op);
+
+    case ir::OpCode::eDclInput:
+    case ir::OpCode::eDclOutput:
+      return emitDclIoVar(op);
+
+    case ir::OpCode::eDclInputBuiltIn:
+    case ir::OpCode::eDclOutputBuiltIn:
+      return emitDclBuiltInIoVar(op);
+
+    case ir::OpCode::eDclParam:
+      /* No-op, resolved when declaring function */
+      return;
+
+    case ir::OpCode::eFunction:
+      return emitFunction(op);
+
+    case ir::OpCode::eFunctionEnd:
+      return emitFunctionEnd();
+
+    case ir::OpCode::eLabel:
+      return emitLabel(op);
+
+    case ir::OpCode::eBranch:
+      return emitBranch(op);
+
+    case ir::OpCode::eBranchConditional:
+      return emitBranchConditional(op);
+
+    case ir::OpCode::eSwitch:
+      return emitSwitch(op);
+
+    case ir::OpCode::eUnreachable:
+      return emitUnreachable();
+
+    case ir::OpCode::eReturn:
+      return emitReturn(op);
+
+    case ir::OpCode::ePhi:
+      return emitPhi(op);
+
+    case ir::OpCode::eScratchLoad:
+    case ir::OpCode::eLdsLoad:
+    case ir::OpCode::ePushDataLoad:
+    case ir::OpCode::eInputLoad:
+    case ir::OpCode::eOutputLoad:
+      return emitLoadVariable(op);
+
+    case ir::OpCode::eScratchStore:
+    case ir::OpCode::eLdsStore:
+    case ir::OpCode::eOutputStore:
+      return emitStoreVariable(op);
+
+    case ir::OpCode::eCompositeInsert:
+    case ir::OpCode::eCompositeExtract:
+      return emitCompositeOp(op);
+
+    case ir::OpCode::eCompositeConstruct:
+      return emitCompositeConstruct(op);
+
+    case ir::OpCode::eSetCsWorkgroupSize:
+    case ir::OpCode::eSetGsInstances:
+    case ir::OpCode::eSetGsInputPrimitive:
+    case ir::OpCode::eSetGsOutputVertices:
+    case ir::OpCode::eSetGsOutputPrimitive:
+    case ir::OpCode::eSetPsEarlyFragmentTest:
+    case ir::OpCode::eSetPsDepthGreaterEqual:
+    case ir::OpCode::eSetPsDepthLessEqual:
+    case ir::OpCode::eSetTessPrimitive:
+    case ir::OpCode::eSetTessDomain:
+    case ir::OpCode::eDclSpecConstant:
+    case ir::OpCode::eDclPushData:
+    case ir::OpCode::eDclSampler:
+    case ir::OpCode::eDclCbv:
+    case ir::OpCode::eDclSrv:
+    case ir::OpCode::eDclUav:
+    case ir::OpCode::eDclUavCounter:
+    case ir::OpCode::eDclLds:
+    case ir::OpCode::eDclScratch:
+    case ir::OpCode::eDclTmp:
+    case ir::OpCode::eFunctionCall:
+    case ir::OpCode::eBarrier:
+    case ir::OpCode::eConvertFtoF:
+    case ir::OpCode::eConvertFtoI:
+    case ir::OpCode::eConvertItoF:
+    case ir::OpCode::eConvertItoI:
+    case ir::OpCode::eCast:
+    case ir::OpCode::eConsumeAs:
+    case ir::OpCode::eCheckSparseAccess:
+    case ir::OpCode::eParamLoad:
+    case ir::OpCode::eTmpLoad:
+    case ir::OpCode::eTmpStore:
+    case ir::OpCode::eSpecConstantLoad:
+    case ir::OpCode::eDescriptorLoad:
+    case ir::OpCode::eBufferLoad:
+    case ir::OpCode::eBufferStore:
+    case ir::OpCode::eBufferQuerySize:
+    case ir::OpCode::eMemoryLoad:
+    case ir::OpCode::eMemoryStore:
+    case ir::OpCode::eLdsAtomic:
+    case ir::OpCode::eBufferAtomic:
+    case ir::OpCode::eImageAtomic:
+    case ir::OpCode::eCounterAtomic:
+    case ir::OpCode::eMemoryAtomic:
+    case ir::OpCode::eImageLoad:
+    case ir::OpCode::eImageStore:
+    case ir::OpCode::eImageQuerySize:
+    case ir::OpCode::eImageQueryMips:
+    case ir::OpCode::eImageQuerySamples:
+    case ir::OpCode::eImageSample:
+    case ir::OpCode::eImageGather:
+    case ir::OpCode::eImageComputeLod:
+    case ir::OpCode::ePointer:
+    case ir::OpCode::ePointerAddress:
+    case ir::OpCode::eEmitVertex:
+    case ir::OpCode::eEmitPrimitive:
+    case ir::OpCode::eDemote:
+    case ir::OpCode::eInterpolateAtCentroid:
+    case ir::OpCode::eInterpolateAtSample:
+    case ir::OpCode::eInterpolateAtOffset:
+    case ir::OpCode::eDerivX:
+    case ir::OpCode::eDerivY:
+    case ir::OpCode::eRovScopedLockBegin:
+    case ir::OpCode::eRovScopedLockEnd:
+    case ir::OpCode::eFEq:
+    case ir::OpCode::eFNe:
+    case ir::OpCode::eFLt:
+    case ir::OpCode::eFLe:
+    case ir::OpCode::eFGt:
+    case ir::OpCode::eFGe:
+    case ir::OpCode::eFIsNan:
+    case ir::OpCode::eIEq:
+    case ir::OpCode::eINe:
+    case ir::OpCode::eSLt:
+    case ir::OpCode::eSGe:
+    case ir::OpCode::eULt:
+    case ir::OpCode::eUGe:
+    case ir::OpCode::eBAnd:
+    case ir::OpCode::eBOr:
+    case ir::OpCode::eBEq:
+    case ir::OpCode::eBNe:
+    case ir::OpCode::eBNot:
+    case ir::OpCode::eSelect:
+    case ir::OpCode::eFAbs:
+    case ir::OpCode::eFNeg:
+    case ir::OpCode::eFAdd:
+    case ir::OpCode::eFSub:
+    case ir::OpCode::eFMul:
+    case ir::OpCode::eFMulLegacy:
+    case ir::OpCode::eFMad:
+    case ir::OpCode::eFMadLegacy:
+    case ir::OpCode::eFDiv:
+    case ir::OpCode::eFRcp:
+    case ir::OpCode::eFSqrt:
+    case ir::OpCode::eFRsq:
+    case ir::OpCode::eFExp2:
+    case ir::OpCode::eFLog2:
+    case ir::OpCode::eFFract:
+    case ir::OpCode::eFRound:
+    case ir::OpCode::eFMin:
+    case ir::OpCode::eFMax:
+    case ir::OpCode::eFDot:
+    case ir::OpCode::eFDotLegacy:
+    case ir::OpCode::eFClamp:
+    case ir::OpCode::eFSin:
+    case ir::OpCode::eFCos:
+    case ir::OpCode::eIAnd:
+    case ir::OpCode::eIOr:
+    case ir::OpCode::eIXor:
+    case ir::OpCode::eINot:
+    case ir::OpCode::eIBitInsert:
+    case ir::OpCode::eUBitExtract:
+    case ir::OpCode::eSBitExtract:
+    case ir::OpCode::eIShl:
+    case ir::OpCode::eSShr:
+    case ir::OpCode::eUShr:
+    case ir::OpCode::eIBitCount:
+    case ir::OpCode::eIBitReverse:
+    case ir::OpCode::eIFindLsb:
+    case ir::OpCode::eSFindMsb:
+    case ir::OpCode::eUFindMsb:
+    case ir::OpCode::eIAdd:
+    case ir::OpCode::eIAddCarry:
+    case ir::OpCode::eISub:
+    case ir::OpCode::eISubBorrow:
+    case ir::OpCode::eINeg:
+    case ir::OpCode::eIMul:
+    case ir::OpCode::eSDiv:
+    case ir::OpCode::eUDiv:
+    case ir::OpCode::eSMin:
+    case ir::OpCode::eSMax:
+    case ir::OpCode::eSClamp:
+    case ir::OpCode::eUMin:
+    case ir::OpCode::eUMax:
+    case ir::OpCode::eUClamp:
+    case ir::OpCode::eUMSad:
+      /* TODO implement */
+      std::cerr << "Unimplemented opcode " << op.getOpCode() << std::endl;
+      break;
+
+    case ir::OpCode::eUnknown:
+    case ir::OpCode::eLastDeclarative:
+    case ir::OpCode::eScopedIf:
+    case ir::OpCode::eScopedElse:
+    case ir::OpCode::eScopedEndIf:
+    case ir::OpCode::eScopedLoop:
+    case ir::OpCode::eScopedLoopBreak:
+    case ir::OpCode::eScopedLoopContinue:
+    case ir::OpCode::eScopedEndLoop:
+    case ir::OpCode::eScopedSwitch:
+    case ir::OpCode::eScopedSwitchCase:
+    case ir::OpCode::eScopedSwitchDefault:
+    case ir::OpCode::eScopedSwitchBreak:
+    case ir::OpCode::eScopedEndSwitch:
+    case ir::OpCode::Count:
+      break;
+  }
+
+  dxbc_spv_unreachable();
+}
+
+
+void SpirvBuilder::emitEntryPoint(const ir::Op& op) {
+  auto stage = ir::ShaderStage(op.getOperand(op.getFirstLiteralOperandIndex()));
+  m_entryPointId = getIdForDef(ir::SsaDef(op.getOperand(0u)));
+
+  spv::ExecutionModel executionModel = [&] {
+    switch (stage) {
+      case ir::ShaderStage::eVertex:
+        return spv::ExecutionModelVertex;
+
+      case ir::ShaderStage::ePixel: {
+        pushOp(m_executionModes, spv::OpExecutionMode, m_entryPointId,
+          spv::ExecutionModeOriginUpperLeft);
+      } return spv::ExecutionModelFragment;
+
+      case ir::ShaderStage::eGeometry: {
+        enableCapability(spv::CapabilityGeometry);
+      } return spv::ExecutionModelGeometry;
+
+      case ir::ShaderStage::eHull: {
+        enableCapability(spv::CapabilityTessellation);
+
+        m_tessControl.controlPointFuncId = getIdForDef(ir::SsaDef(op.getOperand(0u)));
+        m_tessControl.patchConstantFuncId = getIdForDef(ir::SsaDef(op.getOperand(1u)));
+
+        m_entryPointId = allocId();
+      } return spv::ExecutionModelTessellationControl;
+
+      case ir::ShaderStage::eDomain: {
+        enableCapability(spv::CapabilityTessellation);
+      } return spv::ExecutionModelTessellationEvaluation;
+
+      case ir::ShaderStage::eCompute:
+        return spv::ExecutionModelGLCompute;
+
+      case ir::ShaderStage::eFlagEnum:
+        break;
+    }
+
+    dxbc_spv_unreachable();
+    return spv::ExecutionModel();
+  } ();
+
+  /* Emit entry point instruction */
+  const char* name = "main";
+
+  m_entryPoint.push_back(makeOpcodeToken(spv::OpEntryPoint, 3u + getStringDwordCount(name)));
+  m_entryPoint.push_back(executionModel);
+  m_entryPoint.push_back(m_entryPointId);
+  pushString(m_entryPoint, name);
+
+  m_stage = stage;
+}
+
+
+void SpirvBuilder::emitConstant(const ir::Op& op) {
+  uint32_t operandIndex = 0u;
+
+  /* Deduplicate constants once more and assign the ID. This will reliably
+   * work because constants are defined before any of their uses in the IR. */
+  uint32_t defId = op.getDef().getId();
+  uint32_t spvId = makeConstant(op.getType(), op, operandIndex);
+
+  if (defId >= m_ssaDefsToId.size())
+    m_ssaDefsToId.resize(defId + 1u);
+
+  m_ssaDefsToId[defId] = spvId;
+}
+
+
+void SpirvBuilder::emitInterpolationModes(uint32_t id, ir::InterpolationModes modes) {
+  static const std::array<std::pair<ir::InterpolationMode, spv::Decoration>, 4u> s_modes = {{
+    { ir::InterpolationMode::eFlat,           spv::DecorationFlat           },
+    { ir::InterpolationMode::eCentroid,       spv::DecorationCentroid       },
+    { ir::InterpolationMode::eSample,         spv::DecorationSample         },
+    { ir::InterpolationMode::eNoPerspective,  spv::DecorationNoPerspective  },
+  }};
+
+  if (!modes)
+    return;
+
+  if (modes & ir::InterpolationMode::eSample)
+    enableCapability(spv::CapabilitySampleRateShading);
+
+  for (const auto& mode : s_modes) {
+    if (modes & mode.first)
+      pushOp(m_decorations, spv::OpDecorate, id, mode.second);
+  }
+}
+
+
+void SpirvBuilder::emitDclIoVar(const ir::Op& op) {
+  auto storageClass = op.getOpCode() == ir::OpCode::eDclInput
+    ? spv::StorageClassInput
+    : spv::StorageClassOutput;
+
+  uint32_t typeId = getIdForType(op.getType());
+  uint32_t varId = getIdForDef(op.getDef());
+
+  emitDebugName(op.getDef(), varId);
+
+  uint32_t ptrTypeId = getIdForPtrType(typeId, storageClass);
+
+  pushOp(m_declarations, spv::OpVariable, ptrTypeId, varId, storageClass);
+
+  pushOp(m_decorations, spv::OpDecorate, varId, spv::DecorationLocation, uint32_t(op.getOperand(1u)));
+  pushOp(m_decorations, spv::OpDecorate, varId, spv::DecorationComponent, uint32_t(op.getOperand(2u)));
+
+  if (op.getOpCode() == ir::OpCode::eDclInput && m_stage == ir::ShaderStage::ePixel) {
+    auto interpolationModes = ir::InterpolationModes(op.getOperand(3u));
+    emitInterpolationModes(varId, interpolationModes);
+  }
+
+  addEntryPointId(varId);
+}
+
+
+uint32_t SpirvBuilder::emitBuiltInDrawParameter(spv::BuiltIn builtIn) {
+  uint32_t ptrTypeId = getIdForPtrType(getIdForType(ir::ScalarType::eI32), spv::StorageClassInput);
+  uint32_t varId = allocId();
+
+  pushOp(m_declarations, spv::OpVariable, ptrTypeId, varId, spv::StorageClassInput);
+  pushOp(m_decorations, spv::OpDecorate, varId, spv::DecorationBuiltIn, builtIn);
+
+  addEntryPointId(varId);
+  return varId;
+}
+
+
+void SpirvBuilder::emitDclBuiltInIoVar(const ir::Op& op) {
+  auto builtIn = ir::BuiltIn(op.getOperand(1u));
+
+  bool isInput = op.getOpCode() == ir::OpCode::eDclInputBuiltIn;
+  auto storageClass = isInput ? spv::StorageClassInput : spv::StorageClassOutput;
+
+  /* Override type for vertex and instance indices as signed integers.
+   * Subtracting the respective base parameter from it will yield an
+   * unsigned integer. */
+  auto type = op.getType();
+
+  if (builtIn == ir::BuiltIn::eVertexId || builtIn == ir::BuiltIn::eInstanceId)
+    type = ir::ScalarType::eI32;
+
+  uint32_t typeId = getIdForType(type);
+  uint32_t varId = getIdForDef(op.getDef());
+
+  emitDebugName(op.getDef(), varId);
+
+  /* Declare actual variable */
+  uint32_t ptrTypeId = getIdForPtrType(typeId, storageClass);
+  pushOp(m_declarations, spv::OpVariable, ptrTypeId, varId, storageClass);
+
+  /* Declare and handle built-in */
+  spv::BuiltIn spvBuiltIn = [&] {
+    switch (builtIn) {
+      case ir::BuiltIn::ePosition:
+        return m_stage == ir::ShaderStage::ePixel
+          ? spv::BuiltInFragCoord : spv::BuiltInPosition;
+
+      case ir::BuiltIn::eVertexId: {
+        m_drawParams.baseVertex = emitBuiltInDrawParameter(spv::BuiltInBaseVertex);
+
+        enableCapability(spv::CapabilityDrawParameters);
+        return spv::BuiltInVertexIndex;
+      }
+
+      case ir::BuiltIn::eInstanceId: {
+        m_drawParams.baseInstance = emitBuiltInDrawParameter(spv::BuiltInBaseInstance);
+
+        enableCapability(spv::CapabilityDrawParameters);
+        return spv::BuiltInInstanceIndex;
+      }
+
+      case ir::BuiltIn::eClipDistance: {
+        enableCapability(spv::CapabilityClipDistance);
+        return spv::BuiltInClipDistance;
+      }
+
+      case ir::BuiltIn::eCullDistance: {
+        enableCapability(spv::CapabilityCullDistance);
+        return spv::BuiltInCullDistance;
+      }
+
+      case ir::BuiltIn::ePrimitiveId: {
+        if (m_stage == ir::ShaderStage::ePixel)
+          enableCapability(spv::CapabilityGeometry);
+        return spv::BuiltInPrimitiveId;
+      }
+
+      case ir::BuiltIn::eLayerIndex: {
+        if ((m_stage != ir::ShaderStage::eGeometry || isInput) && m_stage != ir::ShaderStage::ePixel)
+          enableCapability(spv::CapabilityShaderLayer);
+        return spv::BuiltInLayer;
+      }
+
+      case ir::BuiltIn::eViewportIndex: {
+        enableCapability(spv::CapabilityMultiViewport);
+
+        if ((m_stage != ir::ShaderStage::eGeometry || isInput) && m_stage != ir::ShaderStage::ePixel)
+          enableCapability(spv::CapabilityShaderViewportIndex);
+
+        return spv::BuiltInViewportIndex;
+      }
+
+      case ir::BuiltIn::eGsInstanceId:
+      case ir::BuiltIn::eTessControlPointId:
+        return spv::BuiltInInvocationId;
+
+      case ir::BuiltIn::eTessCoord:
+        return spv::BuiltInTessCoord;
+
+      case ir::BuiltIn::eTessFactorInner:
+        return spv::BuiltInTessLevelInner;
+
+      case ir::BuiltIn::eTessFactorOuter:
+        return spv::BuiltInTessLevelOuter;
+
+      case ir::BuiltIn::eSampleCount:
+        /* must be lowered */
+        break;
+
+      case ir::BuiltIn::eSampleId: {
+        enableCapability(spv::CapabilitySampleRateShading);
+        return spv::BuiltInSampleId;
+      }
+
+      case ir::BuiltIn::eSamplePosition: {
+        enableCapability(spv::CapabilitySampleRateShading);
+        return spv::BuiltInSamplePosition;
+      }
+
+      case ir::BuiltIn::eSampleMask:
+        return spv::BuiltInSampleMask;
+
+      case ir::BuiltIn::eIsFrontFace:
+        return spv::BuiltInFrontFacing;
+
+      case ir::BuiltIn::eDepth:
+        return spv::BuiltInFragDepth;
+
+      case ir::BuiltIn::eStencilRef: {
+        enableCapability(spv::CapabilityStencilExportEXT);
+        return spv::BuiltInFragStencilRefEXT;
+      }
+
+      case ir::BuiltIn::eWorkgroupId:
+        return spv::BuiltInWorkgroupId;
+
+      case ir::BuiltIn::eGlobalThreadId:
+        return spv::BuiltInGlobalInvocationId;
+
+      case ir::BuiltIn::eLocalThreadId:
+        return spv::BuiltInLocalInvocationId;
+
+      case ir::BuiltIn::eLocalThreadIndex:
+        return spv::BuiltInLocalInvocationIndex;
+    }
+
+    dxbc_spv_unreachable();
+    return spv::BuiltIn();
+  }();
+
+  pushOp(m_decorations, spv::OpDecorate, varId, spv::DecorationBuiltIn, spvBuiltIn);
+
+  /* Set up interpolation modes as neccessary */
+  if (isInput && m_stage == ir::ShaderStage::ePixel) {
+    auto interpolationModes = ir::InterpolationModes(op.getOperand(2u));
+    emitInterpolationModes(varId, interpolationModes);
+  }
+
+  addEntryPointId(varId);
+}
+
+void SpirvBuilder::emitLabel(const ir::Op& op) {
+  m_structure.blockLabel = op;
+
+  pushOp(m_code, spv::OpLabel, getIdForDef(op.getDef()));
+}
+
+
+void SpirvBuilder::emitBranch(const ir::Op& op) {
+  pushOp(m_code, spv::OpBranch, getIdForDef(ir::SsaDef(op.getOperand(0u))));
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitBranchConditional(const ir::Op& op) {
+  emitStructuredInfo(m_structure.blockLabel);
+
+  pushOp(m_code, spv::OpBranchConditional,
+    getIdForDef(ir::SsaDef(op.getOperand(0u))),
+    getIdForDef(ir::SsaDef(op.getOperand(1u))),
+    getIdForDef(ir::SsaDef(op.getOperand(2u))));
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitSwitch(const ir::Op& op) {
+  emitStructuredInfo(m_structure.blockLabel);
+
+  m_code.push_back(makeOpcodeToken(spv::OpSwitch, 1u + op.getOperandCount()));
+  m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(0u))));
+  m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(1u))));
+
+  for (uint32_t i = 2u; i < op.getOperandCount(); i += 2u) {
+    const auto& constant = m_builder.getOp(ir::SsaDef(op.getOperand(i)));
+    dxbc_spv_assert(constant.isConstant());
+
+    m_code.push_back(uint32_t(constant.getOperand(0u)));
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(i + 1u))));
+  }
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitUnreachable() {
+  pushOp(m_code, spv::OpUnreachable);
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitReturn(const ir::Op& op) {
+  if (op.getType().isVoidType()) {
+    pushOp(m_code, spv::OpReturn);
+  } else {
+    pushOp(m_code, spv::OpReturnValue,
+      getIdForType(op.getType()),
+      getIdForDef(ir::SsaDef(op.getOperand(0u))));
+  }
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitPhi(const ir::Op& op) {
+  emitStructuredInfo(m_structure.blockLabel);
+
+  m_code.push_back(makeOpcodeToken(spv::OpPhi, 2u + op.getOperandCount()));
+  m_code.push_back(getIdForType(op.getType()));
+  m_code.push_back(getIdForDef(op.getDef()));
+
+  /* Phi operands are the other way around */
+  for (uint32_t i = 0u; i < op.getOperandCount(); i += 2u) {
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(i + 1u))));
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(i))));
+  }
+
+  m_structure.blockLabel = ir::Op();
+}
+
+
+void SpirvBuilder::emitStructuredInfo(const ir::Op& op) {
+  auto construct = ir::Construct(op.getFirstLiteralOperandIndex());
+
+  switch (construct) {
+    case ir::Construct::eNone:
+      return;
+
+    case ir::Construct::eStructuredSelection: {
+      pushOp(m_code, spv::OpSelectionMerge,
+        getIdForDef(ir::SsaDef(op.getOperand(0u))), 0u);
+    } break;
+
+    case ir::Construct::eStructuredLoop: {
+      pushOp(m_code, spv::OpLoopMerge,
+        getIdForDef(ir::SsaDef(op.getOperand(0u))),
+        getIdForDef(ir::SsaDef(op.getOperand(1u))), 0u);
+    } break;
+  }
+}
+
+
+void SpirvBuilder::emitMemoryModel() {
+  enableCapability(spv::CapabilityShader);
+  enableCapability(spv::CapabilityPhysicalStorageBufferAddresses);
+  enableCapability(spv::CapabilityVulkanMemoryModel);
+
+  pushOp(m_memoryModel, spv::OpMemoryModel,
+    spv::AddressingModelPhysicalStorageBuffer64,
+    spv::MemoryModelVulkan);
+}
+
+
+void SpirvBuilder::emitDebugName(ir::SsaDef def, uint32_t id) {
+  if (!m_options.includeDebugNames)
+    return;
+
+  auto e = m_debugNames.find(def);
+
+  if (e == m_debugNames.end())
+    return;
+
+  const auto& debugOp = m_builder.getOp(e->second);
+  dxbc_spv_assert(debugOp.getOpCode() == ir::OpCode::eDebugName);
+
+  setDebugName(id, debugOp.getLiteralString(1u).c_str());
+}
+
+
+void SpirvBuilder::emitFunction(const ir::Op& op) {
+  uint32_t funcId = getIdForDef(op.getDef());
+  emitDebugName(op.getDef(), funcId);
+
+  /* Look up unique function type */
+  SpirvFunctionTypeKey typeKey = { };
+  typeKey.returnType = op.getType();
+
+  for (uint32_t i = 0u; i < op.getOperandCount(); i++) {
+    const auto& paramDef = m_builder.getOp(ir::SsaDef(op.getOperand(i)));
+    dxbc_spv_assert(paramDef.getOpCode() == ir::OpCode::eDclParam);
+
+    typeKey.paramTypes.push_back(paramDef.getType());
+  }
+
+  /* Emit function declaration */
+  pushOp(m_code, spv::OpFunction,
+    getIdForType(typeKey.returnType),
+    funcId, 0u, getIdForFuncType(typeKey));
+
+  /* Emit function parameters */
+  for (uint32_t i = 0u; i < op.getOperandCount(); i++) {
+    auto paramDef = ir::SsaDef(op.getOperand(i));
+    auto spvId = allocId();
+
+    emitDebugName(paramDef, spvId);
+
+    pushOp(m_code, spv::OpFunctionParameter,
+      getIdForType(typeKey.paramTypes[i]), spvId);
+
+    SpirvFunctionParameterKey key = { };
+    key.funcDef = op.getDef();
+    key.paramDef = paramDef;
+
+    m_funcParamIds.insert({ key, spvId });
+  }
+}
+
+
+void SpirvBuilder::emitFunctionEnd() {
+  pushOp(m_code, spv::OpFunctionEnd);
+}
+
+
+uint32_t SpirvBuilder::emitAccessChain(spv::StorageClass storageClass, ir::SsaDef base, ir::SsaDef address) {
+  if (!address)
+    return getIdForDef(base);
+
+  /* Declare resulting pointer type */
+  auto pointeeType = traverseType(m_builder.getOp(base).getType(), address);
+  auto ptrTypeId = getIdForPtrType(getIdForType(pointeeType), storageClass);
+
+  /* Ensure that the address is an integer scalar or vector.
+   * We already validated everything when traversing the type. */
+  const auto& addressOp = m_builder.getOp(address);
+  auto addressType = addressOp.getType().getBaseType(0u);
+
+  /* Allocate access chain */
+  auto accessChainId = allocId();
+
+  if (addressType.isScalar()) {
+    /* Scalar operand, can use directly no matter what it is. */
+    pushOp(m_code, spv::OpAccessChain, ptrTypeId, accessChainId,
+      getIdForDef(base), getIdForDef(address));
+  } else if (addressOp.isConstant()) {
+    /* Unroll constant operands if possible */
+    util::small_vector<uint32_t, 4u> indexIds;
+
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++)
+      indexIds.push_back(makeConstU32(uint32_t(addressOp.getOperand(i))));
+
+    /* Emit actual access chain instruction */
+    m_code.push_back(makeOpcodeToken(spv::OpAccessChain, 4u + addressType.getVectorSize()));
+    m_code.push_back(ptrTypeId);
+    m_code.push_back(accessChainId);
+    m_code.push_back(getIdForDef(base));
+
+    for (auto index : indexIds)
+      m_code.push_back(index);
+  } else if (addressOp.getOpCode() == ir::OpCode::eCompositeConstruct) {
+    /* Unroll vector operands if possible */
+    m_code.push_back(makeOpcodeToken(spv::OpAccessChain, 4u + addressType.getVectorSize()));
+    m_code.push_back(ptrTypeId);
+    m_code.push_back(accessChainId);
+    m_code.push_back(getIdForDef(base));
+
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++)
+      m_code.push_back(getIdForDef(ir::SsaDef(addressOp.getOperand(i))));
+  } else {
+    /* Dynamically extract vector components */
+    util::small_vector<uint32_t, 4u> indexIds;
+
+    auto scalarTypeId = getIdForType(addressType.getBaseType());
+    auto addressId = getIdForDef(address);
+
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++) {
+      uint32_t componentId = allocId();
+      pushOp(m_code, spv::OpCompositeExtract, scalarTypeId, componentId, addressId, i);
+      indexIds.push_back(componentId);
+    }
+
+    /* Emit actual access chain instruction */
+    m_code.push_back(makeOpcodeToken(spv::OpAccessChain, 4u + addressType.getVectorSize()));
+    m_code.push_back(ptrTypeId);
+    m_code.push_back(accessChainId);
+    m_code.push_back(getIdForDef(base));
+
+    for (auto index : indexIds)
+      m_code.push_back(index);
+  }
+
+  return accessChainId;
+}
+
+
+void SpirvBuilder::emitLoadDrawParameterBuiltIn(const ir::Op& op, ir::BuiltIn builtIn) {
+  /* Can't index into scalar built-ins */
+  dxbc_spv_assert(!ir::SsaDef(op.getOperand(1u)));
+
+  /* The actual built-ins are declared as signed integers */
+  auto intTypeId = getIdForType(ir::ScalarType::eI32);
+
+  auto indexId = allocId();
+  auto baseId = allocId();
+
+  pushOp(m_code, spv::OpLoad, intTypeId, indexId, getIdForDef(ir::SsaDef(op.getOperand(0u))));
+  pushOp(m_code, spv::OpLoad, intTypeId, baseId, builtIn == ir::BuiltIn::eVertexId
+    ? m_drawParams.baseVertex : m_drawParams.baseInstance);
+
+  /* Subtract base index and return the correct type */
+  auto resultTypeId = getIdForType(op.getType());
+  auto id = getIdForDef(op.getDef());
+
+  pushOp(m_code, spv::OpISub, resultTypeId, id, indexId, baseId);
+}
+
+
+void SpirvBuilder::emitLoadVariable(const ir::Op& op) {
+  auto typeId = getIdForType(op.getType());
+
+  /* Loading draw parameter built-ins requires special care */
+  if (op.getOpCode() == ir::OpCode::eInputLoad) {
+    const auto& inputDcl = m_builder.getOp(ir::SsaDef(op.getOperand(0u)));
+
+    if (inputDcl.getOpCode() == ir::OpCode::eDclInputBuiltIn) {
+      auto builtIn = ir::BuiltIn(inputDcl.getOperand(1u));
+
+      if (builtIn == ir::BuiltIn::eVertexId || builtIn == ir::BuiltIn::eInstanceId) {
+        emitLoadDrawParameterBuiltIn(op, builtIn);
+        return;
+      }
+    }
+  }
+
+  /* Load regular variable */
+  auto accessChainId = emitAccessChain(
+    getVariableStorageClass(op),
+    ir::SsaDef(op.getOperand(0u)),
+    ir::SsaDef(op.getOperand(1u)));
+
+  auto id = getIdForDef(op.getDef());
+
+  if (op.getOpCode() == ir::OpCode::eLdsLoad) {
+    uint32_t scopeId = makeConstU32(spv::ScopeWorkgroup);
+
+    pushOp(m_code, spv::OpLoad, typeId, id, accessChainId,
+      spv::MemoryAccessNonPrivatePointerMask |
+      spv::MemoryAccessMakePointerAvailableMask,
+      scopeId);
+  } else {
+    pushOp(m_code, spv::OpLoad, typeId, id, accessChainId);
+  }
+
+  emitDebugName(op.getDef(), id);
+}
+
+
+void SpirvBuilder::emitStoreVariable(const ir::Op& op) {
+  auto accessChainId = emitAccessChain(
+    getVariableStorageClass(op),
+    ir::SsaDef(op.getOperand(0u)),
+    ir::SsaDef(op.getOperand(1u)));
+
+  auto valueId = getIdForDef(ir::SsaDef(op.getOperand(2u)));
+
+  if (op.getOpCode() == ir::OpCode::eLdsStore) {
+    uint32_t scopeId = makeConstU32(spv::ScopeWorkgroup);
+
+    pushOp(m_code, spv::OpStore, accessChainId, valueId,
+      spv::MemoryAccessNonPrivatePointerMask |
+      spv::MemoryAccessMakePointerVisibleMask,
+      scopeId);
+  } else {
+    pushOp(m_code, spv::OpStore, accessChainId, valueId);
+  }
+}
+
+
+void SpirvBuilder::emitCompositeOp(const ir::Op& op) {
+  bool isInsert = op.getOpCode() == ir::OpCode::eCompositeInsert;
+
+  const auto& addressOp = m_builder.getOp(ir::SsaDef(op.getOperand(1u)));
+  dxbc_spv_assert(addressOp.isConstant() && addressOp.getType().isBasicType());
+
+  auto typeId = getIdForType(op.getType());
+  auto spvId = getIdForDef(op.getDef());
+
+  /* Emit actual composite instruction */
+  m_code.push_back(makeOpcodeToken(
+    (isInsert ? spv::OpCompositeInsert : spv::OpCompositeExtract),
+    (isInsert ? 5u : 4u) + addressOp.getOperandCount()));
+  m_code.push_back(typeId);
+  m_code.push_back(spvId);
+
+  /* Value ID to insert */
+  if (isInsert)
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(2u))));
+
+  /* Composite ID */
+  m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(0u))));
+
+  /* Indexing literals */
+  for (uint32_t i = 0u; i < addressOp.getOperandCount(); i++)
+    m_code.push_back(uint32_t(addressOp.getOperand(i)));
+}
+
+
+void SpirvBuilder::emitCompositeConstruct(const ir::Op& op) {
+  auto type = op.getType();
+
+  dxbc_spv_assert(type.isVectorType() || type.isStructType());
+
+  auto typeId = getIdForType(type);
+  auto spvId = getIdForDef(op.getDef());
+
+  m_code.push_back(makeOpcodeToken(spv::OpCompositeConstruct, 3u + op.getOperandCount()));
+  m_code.push_back(typeId);
+  m_code.push_back(spvId);
+
+  for (uint32_t i = 0u; i < op.getOperandCount(); i++)
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(i))));
+}
+
+
+uint32_t SpirvBuilder::importGlslExt() {
+  if (!m_glslExtId) {
+    m_glslExtId = allocId();
+
+    const char* name = "GLSL.std.450";
+    m_imports.push_back(makeOpcodeToken(spv::OpExtInstImport, 2u + getStringDwordCount(name)));
+    m_imports.push_back(m_glslExtId);
+    pushString(m_imports, name);
+  }
+
+  return m_glslExtId;
+}
+
+
+uint32_t SpirvBuilder::allocId() {
+  return m_header.boundIds++;
+}
+
+
+uint32_t SpirvBuilder::getIdForDef(ir::SsaDef def) {
+  if (!def)
+    return 0u;
+
+  uint32_t defId = def.getId();
+
+  if (defId >= m_ssaDefsToId.size())
+    m_ssaDefsToId.resize(defId + 1u);
+
+  auto& spirvId = m_ssaDefsToId[defId];
+
+  if (!spirvId)
+    spirvId = allocId();
+
+  return spirvId;
+}
+
+
+uint32_t SpirvBuilder::getIdForType(const ir::Type& type) {
+  auto entry = m_types.find(type);
+
+  if (entry != m_types.end())
+    return entry->second;
+
+  uint32_t id = defType(type, false);
+  m_types.insert({ type, id });
+  return id;
+}
+
+
+uint32_t SpirvBuilder::defType(const ir::Type& type, bool explicitLayout) {
+  auto id = allocId();
+
+  if (type.isVoidType()) {
+    pushOp(m_declarations, spv::OpTypeVoid, id);
+    return id;
+  }
+
+  if (type.isScalarType()) {
+    uint32_t sign = type.getBaseType(0u).isSignedIntType() ? 1u : 0u;
+
+    switch (type.getBaseType(0u).getBaseType()) {
+      case ir::ScalarType::eBool: {
+        pushOp(m_declarations, spv::OpTypeBool, id);
+      } return id;
+
+      case ir::ScalarType::eI8:
+      case ir::ScalarType::eU8: {
+        enableCapability(spv::CapabilityInt8);
+        pushOp(m_declarations, spv::OpTypeInt, id, 8u, sign);
+      } return id;
+
+      case ir::ScalarType::eI16:
+      case ir::ScalarType::eU16: {
+        enableCapability(spv::CapabilityInt16);
+        pushOp(m_declarations, spv::OpTypeInt, id, 16u, sign);
+      } return id;
+
+      case ir::ScalarType::eI32:
+      case ir::ScalarType::eU32: {
+        pushOp(m_declarations, spv::OpTypeInt, id, 32u, sign);
+      } return id;
+
+      case ir::ScalarType::eI64:
+      case ir::ScalarType::eU64: {
+        enableCapability(spv::CapabilityInt64);
+        pushOp(m_declarations, spv::OpTypeInt, id, 64u, sign);
+      } return id;
+
+      case ir::ScalarType::eF16: {
+        enableCapability(spv::CapabilityFloat16);
+        pushOp(m_declarations, spv::OpTypeFloat, id, 16u);
+      } return id;
+
+      case ir::ScalarType::eF32: {
+        pushOp(m_declarations, spv::OpTypeFloat, id, 32u);
+      } return id;
+
+      case ir::ScalarType::eF64: {
+        enableCapability(spv::CapabilityFloat64);
+        pushOp(m_declarations, spv::OpTypeFloat, id, 64u);
+      } return id;
+
+      default:
+        dxbc_spv_unreachable();
+        return 0u;
+    }
+  }
+
+  if (type.isVectorType()) {
+    auto baseType = type.getBaseType(0u);
+    auto baseTypeId = getIdForType(baseType.getBaseType());
+
+    pushOp(m_declarations, spv::OpTypeVector, id,
+      baseTypeId, baseType.getVectorSize());
+    return id;
+  }
+
+  if (type.isStructType()) {
+    util::small_vector<uint32_t, 16u> memberTypeIds;
+
+    for (uint32_t i = 0u; i < type.getStructMemberCount(); i++)
+      memberTypeIds.push_back(getIdForType(type.getBaseType(i)));
+
+    m_declarations.push_back(makeOpcodeToken(spv::OpTypeStruct, 2u + type.getStructMemberCount()));
+    m_declarations.push_back(id);
+
+    for (uint32_t i = 0u; i < type.getStructMemberCount(); i++) {
+      m_declarations.push_back(memberTypeIds[i]);
+
+      if (explicitLayout) {
+        pushOp(m_decorations, spv::OpMemberDecorate, id, i,
+          spv::DecorationOffset, type.byteOffset(i));
+      }
+    }
+
+    return id;
+  }
+
+  if (type.isArrayType()) {
+    auto baseType = type.getSubType(0u);
+    auto baseTypeId = explicitLayout && !baseType.isBasicType()
+      ? defType(baseType, explicitLayout)
+      : getIdForType(baseType);
+
+    if (type.isSizedArray()) {
+      pushOp(m_declarations, spv::OpTypeArray, id, baseTypeId,
+        makeConstU32(type.computeTopLevelMemberCount()));
+    } else {
+      pushOp(m_declarations, spv::OpTypeRuntimeArray, id, baseTypeId);
+    }
+
+    if (explicitLayout) {
+      pushOp(m_decorations, spv::OpDecorate, id,
+        spv::DecorationArrayStride, baseType.byteSize());
+    }
+
+    return id;
+  }
+
+  dxbc_spv_unreachable();
+  return 0u;
+}
+
+
+uint32_t SpirvBuilder::getIdForPtrType(uint32_t typeId, spv::StorageClass storageClass) {
+  SpirvPointerTypeKey key = { typeId, storageClass };
+
+  auto entry = m_ptrTypes.find(key);
+
+  if (entry != m_ptrTypes.end())
+    return entry->second;
+
+  uint32_t id = allocId();
+
+  pushOp(m_declarations, spv::OpTypePointer, id, storageClass, typeId);
+
+  m_ptrTypes.insert({ key, id });
+  return id;
+}
+
+
+uint32_t SpirvBuilder::getIdForFuncType(const SpirvFunctionTypeKey& key) {
+  auto entry = m_funcTypes.find(key);
+
+  if (entry != m_funcTypes.end())
+    return entry->second;
+
+  uint32_t returnTypeId = getIdForType(key.returnType);
+
+  util::small_vector<uint32_t, 4u> paramTypeIds;
+
+  for (const auto& t : key.paramTypes)
+    paramTypeIds.push_back(getIdForType(t));
+
+  uint32_t id = allocId();
+
+  m_declarations.push_back(makeOpcodeToken(spv::OpTypeFunction, 3u + key.paramTypes.size()));
+  m_declarations.push_back(id);
+  m_declarations.push_back(returnTypeId);
+
+  for (const auto& t : paramTypeIds)
+    m_declarations.push_back(t);
+
+  m_funcTypes.insert({ key, id });
+  return id;
+}
+
+
+uint32_t SpirvBuilder::getIdForConstant(const SpirvConstant& constant, uint32_t memberCount) {
+  auto entry = m_constants.find(constant);
+
+  if (entry != m_constants.end())
+    return entry->second;
+
+  uint32_t id = allocId();
+
+  m_declarations.push_back(makeOpcodeToken(constant.op, 3u + memberCount));
+  m_declarations.push_back(constant.typeId);
+  m_declarations.push_back(id);
+
+  for (uint32_t i = 0u; i < memberCount; i++)
+    m_declarations.push_back(constant.constituents[i]);
+
+  return id;
+}
+
+
+uint32_t SpirvBuilder::makeScalarConst(ir::ScalarType type, const ir::Op& op, uint32_t& operandIndex) {
+  switch (type) {
+    case ir::ScalarType::eBool:
+      return makeConstBool(bool(op.getOperand(operandIndex++)));
+
+    case ir::ScalarType::eI8:
+    case ir::ScalarType::eU8:
+    case ir::ScalarType::eI16:
+    case ir::ScalarType::eU16:
+    case ir::ScalarType::eF16:
+    case ir::ScalarType::eI32:
+    case ir::ScalarType::eU32:
+    case ir::ScalarType::eF32: {
+      SpirvConstant constant = { };
+      constant.op = spv::OpConstant;
+      constant.typeId = getIdForType(type);
+      constant.constituents[0u] = uint32_t(op.getOperand(operandIndex++));
+      return getIdForConstant(constant, 1u);
+    }
+
+    case ir::ScalarType::eI64:
+    case ir::ScalarType::eU64:
+    case ir::ScalarType::eF64: {
+      auto literal = uint64_t(op.getOperand(operandIndex++));
+
+      SpirvConstant constant = { };
+      constant.op = spv::OpConstant;
+      constant.typeId = getIdForType(type);
+      constant.constituents[0u] = uint32_t(literal);
+      constant.constituents[1u] = uint32_t(literal >> 32u);
+      return getIdForConstant(constant, 2u);
+    }
+
+    default:
+      dxbc_spv_unreachable();
+      return 0u;
+  }
+}
+
+
+uint32_t SpirvBuilder::makeBasicConst(ir::BasicType type, const ir::Op& op, uint32_t& operandIndex) {
+  if (type.isScalar())
+    return makeScalarConst(type.getBaseType(), op, operandIndex);
+
+  SpirvConstant constant = { };
+  constant.op = spv::OpConstantComposite;
+  constant.typeId = getIdForType(type);
+
+  for (uint32_t i = 0u; i < type.getVectorSize(); i++)
+    constant.constituents[i] = makeScalarConst(type.getBaseType(), op, operandIndex);
+
+  return getIdForConstant(constant, type.getVectorSize());
+}
+
+
+uint32_t SpirvBuilder::makeConstant(const ir::Type& type, const ir::Op& op, uint32_t& operandIndex) {
+  if (type.isBasicType())
+    return makeBasicConst(type.getBaseType(0u), op, operandIndex);
+
+  /* Recursively emit member constants */
+  util::small_vector<uint32_t, 16u> memberIds = { };
+
+  for (uint32_t i = 0u; i < type.computeTopLevelMemberCount(); i++)
+    memberIds.push_back(makeConstant(type.getSubType(i), op, operandIndex));
+
+  /* Don't bother deduplicating struct or array constants,
+   * we already do this at an IR level. */
+  uint32_t typeId = getIdForType(type);
+  uint32_t id = allocId();
+
+  m_declarations.push_back(makeOpcodeToken(spv::OpConstantComposite, 3u + memberIds.size()));
+  m_declarations.push_back(typeId);
+  m_declarations.push_back(id);
+
+  for (auto memberId : memberIds)
+    m_declarations.push_back(memberId);
+
+  return id;
+}
+
+
+uint32_t SpirvBuilder::makeConstBool(bool value) {
+  SpirvConstant constant = { };
+  constant.op = value ? spv::OpConstantTrue : spv::OpConstantFalse;
+  constant.typeId = getIdForType(ir::ScalarType::eBool);
+  return getIdForConstant(constant, 0u);
+}
+
+
+uint32_t SpirvBuilder::makeConstU32(uint32_t value) {
+  SpirvConstant constant = { };
+  constant.op = spv::OpConstant;
+  constant.typeId = getIdForType(ir::ScalarType::eU32);
+  constant.constituents[0u] = value;
+  return getIdForConstant(constant, 1u);
+}
+
+
+uint32_t SpirvBuilder::makeConstI32(int32_t value) {
+  SpirvConstant constant = { };
+  constant.op = spv::OpConstant;
+  constant.typeId = getIdForType(ir::ScalarType::eI32);
+  constant.constituents[0u] = value;
+  return getIdForConstant(constant, 1u);
+}
+
+
+uint32_t SpirvBuilder::makeConstNull(uint32_t typeId) {
+  SpirvConstant constant = { };
+  constant.op = spv::OpConstantNull;
+  constant.typeId = typeId;
+  return getIdForConstant(constant, 0u);
+}
+
+
+uint32_t SpirvBuilder::makeUndef(uint32_t typeId) {
+  SpirvConstant constant = { };
+  constant.op = spv::OpUndef;
+  constant.typeId = typeId;
+  return getIdForConstant(constant, 0u);
+}
+
+
+void SpirvBuilder::setDebugName(uint32_t id, const char* name) {
+  m_debug.push_back(makeOpcodeToken(spv::OpName, 2u + getStringDwordCount(name)));
+  m_debug.push_back(id);
+  pushString(m_debug, name);
+}
+
+
+void SpirvBuilder::setDebugMemberName(uint32_t id, uint32_t member, const char* name) {
+  m_debug.push_back(makeOpcodeToken(spv::OpMemberName, 3u + getStringDwordCount(name)));
+  m_debug.push_back(id);
+  m_debug.push_back(member);
+  pushString(m_debug, name);
+}
+
+
+void SpirvBuilder::enableCapability(spv::Capability cap) {
+  if (m_enabledCaps.find(cap) != m_enabledCaps.end())
+    return;
+
+  pushOp(m_capabilities, spv::OpCapability, cap);
+  m_enabledCaps.insert(cap);
+
+  switch (cap) {
+    case spv::CapabilityFragmentShaderSampleInterlockEXT:
+    case spv::CapabilityFragmentShaderPixelInterlockEXT:
+      enableExtension("SPV_EXT_fragment_shader_interlock");
+      break;
+
+    case spv::CapabilityStencilExportEXT:
+      enableExtension("SPV_EXT_shader_stencil_export");
+      break;
+
+    case spv::CapabilityFragmentFullyCoveredEXT:
+      enableExtension("SPV_EXT_fragment_fully_covered");
+      break;
+
+    case spv::CapabilityRawAccessChainsNV:
+      enableExtension("SPV_NV_raw_access_chains");
+      break;
+
+    default: ;
+  }
+}
+
+
+void SpirvBuilder::enableExtension(const char* name) {
+  if (m_enabledExt.find(name) != m_enabledExt.end())
+    return;
+
+  m_enabledExt.emplace(name);
+
+  m_extensions.push_back(makeOpcodeToken(spv::OpExtension,
+    1u + getStringDwordCount(name)));
+  pushString(m_extensions, name);
+}
+
+
+void SpirvBuilder::addEntryPointId(uint32_t id) {
+  dxbc_spv_assert(!m_entryPoint.empty());
+
+  m_entryPoint.front() += 1u << spv::WordCountShift;
+  m_entryPoint.push_back(id);
+}
+
+
+ir::Type SpirvBuilder::traverseType(ir::Type type, ir::SsaDef address) const {
+  if (!address)
+    return type;
+
+  const auto& addressOp = m_builder.getOp(address);
+  dxbc_spv_assert(addressOp.getType().isBasicType());
+
+  auto addressType = addressOp.getType().getBaseType(0u);
+  dxbc_spv_assert(addressType.isIntType());
+
+  if (addressOp.isConstant()) {
+    /* Constant indices only, trivial case. */
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++)
+      type = type.getSubType(uint32_t(addressOp.getOperand(i)));
+
+    return type;
+  } else if (addressOp.getOpCode() == ir::OpCode::eCompositeConstruct) {
+    /* Mixture of constant and dynamic indexing, handle appropriately. */
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++) {
+      const auto& indexOp = m_builder.getOp(ir::SsaDef(addressOp.getOperand(i)));
+      dxbc_spv_assert(type.isArrayType() || indexOp.isConstant());
+
+      uint32_t index = 0u;
+
+      if (indexOp.isConstant()) {
+        dxbc_spv_assert(indexOp.getType().isScalarType());
+        index = uint32_t(indexOp.getOperand(0u));
+      }
+
+      type = type.getSubType(index);
+    }
+
+    return type;
+  } else {
+    /* Indices can be anything, shouldn't really happen but w/e. */
+    for (uint32_t i = 0u; i < addressType.getVectorSize(); i++) {
+      dxbc_spv_assert(type.isArrayType());
+      type = type.getSubType(0u);
+    }
+
+    return type;
+  }
+}
+
+
+spv::StorageClass SpirvBuilder::getVariableStorageClass(const ir::Op& op) {
+  switch (op.getOpCode()) {
+    case ir::OpCode::eParamLoad:
+      return spv::StorageClassFunction;
+
+    case ir::OpCode::eTmpLoad:
+    case ir::OpCode::eTmpStore:
+    case ir::OpCode::eScratchLoad:
+    case ir::OpCode::eScratchStore:
+      return spv::StorageClassPrivate;
+
+    case ir::OpCode::eLdsLoad:
+    case ir::OpCode::eLdsStore:
+      return spv::StorageClassWorkgroup;
+
+    case ir::OpCode::ePushDataLoad:
+      return spv::StorageClassPushConstant;
+
+    case ir::OpCode::eInputLoad:
+      return spv::StorageClassInput;
+
+    case ir::OpCode::eOutputLoad:
+    case ir::OpCode::eOutputStore:
+      return spv::StorageClassOutput;
+
+    default:
+      dxbc_spv_unreachable();
+      return spv::StorageClass();
+  }
+}
+
+
+uint32_t SpirvBuilder::makeOpcodeToken(spv::Op op, uint32_t len) {
+  return uint32_t(op) | (len << spv::WordCountShift);
+}
+
+
+uint32_t SpirvBuilder::getStringDwordCount(const char* str) {
+  return std::strlen(str) / sizeof(uint32_t) + 1u;
+}
+
+
+template<typename T, typename... Args>
+void SpirvBuilder::pushOp(T& container, spv::Op op, Args... args) {
+  container.push_back(makeOpcodeToken(op, 1u + sizeof...(args)));
+  (container.push_back(args), ...);
+}
+
+
+template<typename T>
+void SpirvBuilder::pushString(T& container, const char* str) {
+  uint32_t dword = 0u;
+
+  for (uint32_t i = 0u; str[i]; i++) {
+    dword |= uint32_t(uint8_t(str[i])) << (8u * (i % sizeof(dword)));
+
+    if (!((i + 1u) % sizeof(dword))) {
+      container.push_back(dword);
+      dword = 0u;
+    }
+  }
+
+  container.push_back(dword);
+}
+
+}

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -1803,11 +1803,13 @@ void SpirvBuilder::emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t o
   m_code.push_back(makeConstU32(scope));
   m_code.push_back(makeConstU32(memoryTypes | semantics));
 
-  if (atomicOp == ir::AtomicOp::eCompareExchange)
+  if (atomicOp == ir::AtomicOp::eCompareExchange) {
     m_code.push_back(makeConstU32(memoryTypes | spv::MemorySemanticsAcquireMask));
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(operandIndex + 1u))));
+  }
 
-  for (uint32_t i = 0u; i < argCount; i++)
-    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(operandIndex + i))));
+  if (argCount)
+    m_code.push_back(getIdForDef(ir::SsaDef(op.getOperand(operandIndex))));
 
   emitDebugName(op.getDef(), id);
 }

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -162,6 +162,8 @@ private:
 
   void emitConvert(const ir::Op& op);
 
+  void emitDerivative(const ir::Op& op);
+
   void emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t operandIndex,
       uint32_t ptrId, spv::Scope scope, spv::MemorySemanticsMask memoryTypes);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -151,6 +151,8 @@ private:
 
   void emitCompositeConstruct(const ir::Op& op);
 
+  void emitSimpleArithmetic(const ir::Op& op);
+
   uint32_t importGlslExt();
 
   uint32_t allocId();

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -121,6 +121,10 @@ private:
 
   void emitDclSrvUav(const ir::Op& op);
 
+  uint32_t getDescriptorArrayIndex(const ir::Op& op);
+
+  uint32_t getImageDescriptorPointer(const ir::Op& op);
+
   void emitDescriptorLoad(const ir::Op& op);
 
   void emitBufferLoad(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -58,10 +58,12 @@ private:
   std::unordered_map<ir::SsaDef, ir::SsaDef> m_debugNames;
   std::unordered_map<SpirvPointerTypeKey, uint32_t> m_ptrTypes;
   std::unordered_map<SpirvFunctionTypeKey, uint32_t> m_funcTypes;
+  std::unordered_map<SpirvImageTypeKey, uint32_t> m_imageTypes;
   std::unordered_map<SpirvConstant, uint32_t> m_constants;
   std::unordered_set<spv::Capability> m_enabledCaps;
   std::unordered_set<std::string> m_enabledExt;
   std::unordered_map<SpirvFunctionParameterKey, uint32_t> m_funcParamIds;
+  std::unordered_map<ir::SsaDef, uint32_t> m_descriptorTypes;
 
   std::vector<uint32_t> m_ssaDefsToId;
 
@@ -115,6 +117,20 @@ private:
 
   void emitDclBuiltInIoVar(const ir::Op& op);
 
+  void emitDclCbv(const ir::Op& op);
+
+  void emitDclSrvUav(const ir::Op& op);
+
+  void emitDescriptorLoad(const ir::Op& op);
+
+  void emitBufferLoad(const ir::Op& op);
+
+  void emitBufferStore(const ir::Op& op);
+
+  void emitBufferQuery(const ir::Op& op);
+
+  void emitConvert(const ir::Op& op);
+
   void emitFunction(const ir::Op& op);
 
   void emitFunctionEnd();
@@ -139,7 +155,18 @@ private:
 
   void emitDebugName(ir::SsaDef def, uint32_t id);
 
+  uint32_t emitAddressOffset(ir::SsaDef def, uint32_t offset);
+
+  uint32_t emitAccessChain(spv::StorageClass storageClass, const ir::Type& baseType,
+    uint32_t baseId, ir::SsaDef address, uint32_t offset, bool wrapperStruct);
+
   uint32_t emitAccessChain(spv::StorageClass storageClass, ir::SsaDef base, ir::SsaDef address);
+
+  uint32_t emitRawStrutcuredElementAddress(const ir::Op& op, uint32_t depth, uint32_t stride);
+
+  uint32_t emitRawAccessChainNv(spv::StorageClass storageClass, const ir::Type& type, const ir::Op& resourceOp, uint32_t baseId, ir::SsaDef address);
+
+  void emitCheckSparseAccess(const ir::Op& op);
 
   void emitLoadDrawParameterBuiltIn(const ir::Op& op, ir::BuiltIn builtIn);
 
@@ -157,15 +184,23 @@ private:
 
   uint32_t allocId();
 
+  void setIdForDef(ir::SsaDef def, uint32_t id);
+
   uint32_t getIdForDef(ir::SsaDef def);
 
   uint32_t getIdForType(const ir::Type& type);
 
   uint32_t defType(const ir::Type& type, bool explicitLayout);
 
+  uint32_t defStructWrapper(uint32_t typeId);
+
+  uint32_t defDescriptor(const ir::Op& op, uint32_t typeId, spv::StorageClass storageClass);
+
   uint32_t getIdForPtrType(uint32_t typeId, spv::StorageClass storageClass);
 
   uint32_t getIdForFuncType(const SpirvFunctionTypeKey& key);
+
+  uint32_t getIdForImageType(const SpirvImageTypeKey& key);
 
   uint32_t getIdForConstant(const SpirvConstant& constant, uint32_t memberCount);
 
@@ -195,7 +230,15 @@ private:
 
   void addEntryPointId(uint32_t id);
 
+  bool declaresPlainBufferResource(ir::Op op);
+
+  uint32_t getDescriptorArraySize(ir::Op op);
+
   ir::Type traverseType(ir::Type type, ir::SsaDef address) const;
+
+  static ir::UavFlags getUavFlags(const ir::Op& op);
+
+  static ir::ResourceKind getResourceKind(const ir::Op& op);
 
   static spv::StorageClass getVariableStorageClass(const ir::Op& op);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -150,6 +150,8 @@ private:
 
   void emitImageLoad(const ir::Op& op);
 
+  void emitImageSample(const ir::Op& op);
+
   void emitImageComputeLod(const ir::Op& op);
 
   void emitImageQuerySize(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -139,6 +139,10 @@ private:
 
   void emitCounterAtomic(const ir::Op& op);
 
+  uint32_t emitMergeImageCoordLayer(const ir::SsaDef& coordDef, const ir::SsaDef& layerDef);
+
+  void emitImageLoad(const ir::Op& op);
+
   void emitImageQuerySize(const ir::Op& op);
 
   void emitImageQueryMips(const ir::Op& op);
@@ -254,6 +258,10 @@ private:
   bool declaresPlainBufferResource(const ir::Op& op);
 
   uint32_t getDescriptorArraySize(const ir::Op& op);
+
+  void setUavImageReadOperands(SpirvImageOperands& operands, const ir::Op& uavOp);
+
+  void setUavImageWriteOperands(SpirvImageOperands& operands, const ir::Op& uavOp);
 
   ir::Type traverseType(ir::Type type, ir::SsaDef address) const;
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -144,9 +144,13 @@ private:
 
   void emitCounterAtomic(const ir::Op& op);
 
+  uint32_t emitSampledImage(const ir::SsaDef& imageDef, const ir::SsaDef& samplerDef);
+
   uint32_t emitMergeImageCoordLayer(const ir::SsaDef& coordDef, const ir::SsaDef& layerDef);
 
   void emitImageLoad(const ir::Op& op);
+
+  void emitImageComputeLod(const ir::Op& op);
 
   void emitImageQuerySize(const ir::Op& op);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -152,6 +152,8 @@ private:
 
   void emitImageSample(const ir::Op& op);
 
+  void emitImageGather(const ir::Op& op);
+
   void emitImageComputeLod(const ir::Op& op);
 
   void emitImageQuerySize(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -152,6 +152,8 @@ private:
 
   void emitImageStore(const ir::Op& op);
 
+  void emitImageAtomic(const ir::Op& op);
+
   void emitImageSample(const ir::Op& op);
 
   void emitImageGather(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -121,6 +121,8 @@ private:
 
   void emitDclSrvUav(const ir::Op& op);
 
+  void emitDclUavCounter(const ir::Op& op);
+
   uint32_t getDescriptorArrayIndex(const ir::Op& op);
 
   uint32_t getImageDescriptorPointer(const ir::Op& op);
@@ -134,6 +136,8 @@ private:
   void emitBufferQuery(const ir::Op& op);
 
   void emitBufferAtomic(const ir::Op& op);
+
+  void emitCounterAtomic(const ir::Op& op);
 
   void emitImageQuerySize(const ir::Op& op);
 
@@ -247,9 +251,9 @@ private:
 
   void addEntryPointId(uint32_t id);
 
-  bool declaresPlainBufferResource(ir::Op op);
+  bool declaresPlainBufferResource(const ir::Op& op);
 
-  uint32_t getDescriptorArraySize(ir::Op op);
+  uint32_t getDescriptorArraySize(const ir::Op& op);
 
   ir::Type traverseType(ir::Type type, ir::SsaDef address) const;
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -150,6 +150,8 @@ private:
 
   void emitImageLoad(const ir::Op& op);
 
+  void emitImageStore(const ir::Op& op);
+
   void emitImageSample(const ir::Op& op);
 
   void emitImageGather(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -63,6 +63,7 @@ private:
   std::unordered_set<spv::Capability> m_enabledCaps;
   std::unordered_set<std::string> m_enabledExt;
   std::unordered_map<SpirvFunctionParameterKey, uint32_t> m_funcParamIds;
+  std::unordered_map<uint32_t, uint32_t> m_sampledImageTypeIds;
   std::unordered_map<ir::SsaDef, uint32_t> m_descriptorTypes;
 
   std::vector<uint32_t> m_ssaDefsToId;
@@ -232,6 +233,8 @@ private:
   uint32_t getIdForImageType(const SpirvImageTypeKey& key);
 
   uint32_t getIdForSamplerType();
+
+  uint32_t getIdForSampledImageType(uint32_t imageTypeId);
 
   uint32_t getIdForConstant(const SpirvConstant& constant, uint32_t memberCount);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -133,7 +133,12 @@ private:
 
   void emitBufferQuery(const ir::Op& op);
 
+  void emitBufferAtomic(const ir::Op& op);
+
   void emitConvert(const ir::Op& op);
+
+  void emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t operandIndex,
+      uint32_t ptrId, spv::Scope scope, spv::MemorySemanticsMask memoryTypes);
 
   void emitFunction(const ir::Op& op);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -83,6 +83,8 @@ private:
 
   uint32_t m_glslExtId = 0u;
 
+  uint32_t m_samplerTypeId = 0u;
+
   struct {
     ir::Op blockLabel = { };
   } m_structure;
@@ -116,6 +118,8 @@ private:
   uint32_t emitBuiltInDrawParameter(spv::BuiltIn builtIn);
 
   void emitDclBuiltInIoVar(const ir::Op& op);
+
+  void emitDclSampler(const ir::Op& op);
 
   void emitDclCbv(const ir::Op& op);
 
@@ -226,6 +230,8 @@ private:
   uint32_t getIdForFuncType(const SpirvFunctionTypeKey& key);
 
   uint32_t getIdForImageType(const SpirvImageTypeKey& key);
+
+  uint32_t getIdForSamplerType();
 
   uint32_t getIdForConstant(const SpirvConstant& constant, uint32_t memberCount);
 

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -135,6 +135,12 @@ private:
 
   void emitBufferAtomic(const ir::Op& op);
 
+  void emitImageQuerySize(const ir::Op& op);
+
+  void emitImageQueryMips(const ir::Op& op);
+
+  void emitImageQuerySamples(const ir::Op& op);
+
   void emitConvert(const ir::Op& op);
 
   void emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t operandIndex,

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -195,6 +195,8 @@ private:
 
   void emitSimpleArithmetic(const ir::Op& op);
 
+  void emitSetCsWorkgroupSize(const ir::Op& op);
+
   uint32_t importGlslExt();
 
   uint32_t allocId();

--- a/spirv/spirv_types.h
+++ b/spirv/spirv_types.h
@@ -1,0 +1,144 @@
+#include <spirv/unified1/spirv.hpp>
+#include <spirv/unified1/GLSL.std.450.h>
+
+#include "../ir/ir.h"
+#include "../ir/ir_builder.h"
+
+#include "../util/util_hash.h"
+#include "../util/util_small_vector.h"
+
+namespace dxbc_spv::spirv {
+
+/** SPIR-V binary header */
+struct SpirvHeader {
+  uint32_t magic = spv::MagicNumber;
+  uint32_t version = 0x10600u;
+  uint32_t generator = 0u;
+  uint32_t boundIds = 1u;
+  uint32_t schema = 0u;
+};
+
+
+/** Key for pointer type look-up. Associates
+ *  an existing type with a storage class. */
+struct SpirvPointerTypeKey {
+  uint32_t baseTypeId = 0u;
+  spv::StorageClass storageClass = spv::StorageClass(0u);
+
+  bool operator == (const SpirvPointerTypeKey& other) const {
+    return baseTypeId == other.baseTypeId &&
+           storageClass == other.storageClass;
+  }
+
+  bool operator != (const SpirvPointerTypeKey& other) const {
+    return !(operator == (other));
+  }
+};
+
+
+/** Key for function type look-up. Consists of a return value
+ *  type which may be void, and a list of parameter types. */
+struct SpirvFunctionTypeKey {
+  ir::Type returnType;
+  util::small_vector<ir::Type, 4u> paramTypes;
+
+  bool operator == (const SpirvFunctionTypeKey& other) const {
+    bool eq = returnType == other.returnType &&
+              paramTypes.size() == other.paramTypes.size();
+
+    for (size_t i = 0u; i < paramTypes.size() && eq; i++)
+      eq = paramTypes[i] == other.paramTypes[i];
+
+    return eq;
+  }
+
+  bool operator != (const SpirvFunctionTypeKey& other) const {
+    return !(operator == (other));
+  }
+};
+
+
+/** Function parameter association. Useful to generate a unique
+ *  ID for a function parameter in a given function. */
+struct SpirvFunctionParameterKey {
+  ir::SsaDef funcDef;
+  ir::SsaDef paramDef;
+
+  bool operator == (const SpirvFunctionParameterKey& other) const {
+    return funcDef == other.funcDef && paramDef == other.paramDef;
+  }
+
+  bool operator != (const SpirvFunctionParameterKey& other) const {
+    return !(operator == (other));
+  }
+};
+
+
+/** Basic scalar or vector constant look-up structure
+ *  for constant deduplication. */
+struct SpirvConstant {
+  spv::Op op = spv::OpNop;
+  uint32_t typeId = 0u;
+  std::array<uint32_t, 4u> constituents = { };
+
+  bool operator == (const SpirvConstant& other) const {
+    bool eq = op == other.op && typeId == other.typeId;
+
+    for (size_t i = 0u; i < constituents.size() && eq; i++)
+      eq = constituents[i] == other.constituents[i];
+
+    return eq;
+  }
+
+  bool operator != (const SpirvConstant& other) const {
+    return !(operator == (other));
+  }
+};
+
+}
+
+
+namespace std {
+
+template<>
+struct hash<dxbc_spv::spirv::SpirvPointerTypeKey> {
+  size_t operator () (const dxbc_spv::spirv::SpirvPointerTypeKey& k) const {
+    return dxbc_spv::util::hash_combine(uint32_t(k.baseTypeId), uint32_t(k.storageClass));
+  }
+};
+
+template<>
+struct hash<dxbc_spv::spirv::SpirvFunctionTypeKey> {
+  size_t operator () (const dxbc_spv::spirv::SpirvFunctionTypeKey& k) const {
+    size_t hash = std::hash<dxbc_spv::ir::Type>()(k.returnType);
+
+    for (const auto& t : k.paramTypes)
+      hash = dxbc_spv::util::hash_combine(hash, std::hash<dxbc_spv::ir::Type>()(t));
+
+    return hash;
+  }
+};
+
+template<>
+struct hash<dxbc_spv::spirv::SpirvFunctionParameterKey> {
+  size_t operator () (const dxbc_spv::spirv::SpirvFunctionParameterKey& k) const {
+    return dxbc_spv::util::hash_combine(
+      std::hash<dxbc_spv::ir::SsaDef>()(k.funcDef),
+      std::hash<dxbc_spv::ir::SsaDef>()(k.paramDef));
+  }
+};
+
+template<>
+struct hash<dxbc_spv::spirv::SpirvConstant> {
+  size_t operator () (const dxbc_spv::spirv::SpirvConstant& c) const {
+    size_t hash = uint32_t(c.op);
+    hash = dxbc_spv::util::hash_combine(hash, c.typeId);
+
+    for (uint32_t i = 0u; i < c.constituents.size(); i++)
+      hash = dxbc_spv::util::hash_combine(hash, c.constituents[i]);
+
+    return hash;
+  }
+};
+
+}

--- a/tests/api/test_api_resources.cpp
+++ b/tests/api/test_api_resources.cpp
@@ -218,6 +218,26 @@ Builder make_test_buffer_load(ResourceKind kind, bool uav, bool indexed) {
   builder.add(Op::Semantic(output1Def, 1u, "SV_TARGET"));
   builder.add(Op::OutputStore(output1Def, SsaDef(), data1));
 
+  if (kind == ResourceKind::eBufferStructured) {
+    auto type = BasicType(ScalarType::eU32, 4u);
+
+    auto index2 = builder.makeConstant(16u, 11u);
+    auto data2 = builder.add(Op::BufferLoad(type, descriptor, index2, 4u));
+
+    auto output2Def = builder.add(Op::DclOutput(type, entryPoint, 2u, 0u));
+    builder.add(Op::Semantic(output2Def, 2u, "SV_TARGET"));
+    builder.add(Op::OutputStore(output2Def, SsaDef(), data2));
+  }
+
+  if (kind != ResourceKind::eBufferTyped) {
+    auto type = BasicType(ScalarType::eU32, 1u);
+    auto data3 = builder.add(Op::BufferLoad(type, descriptor, index0, 4u));
+
+    auto output3Def = builder.add(Op::DclOutput(type, entryPoint, 3u, 0u));
+    builder.add(Op::Semantic(output3Def, 3u, "SV_TARGET"));
+    builder.add(Op::OutputStore(output3Def, SsaDef(), data3));
+  }
+
   builder.add(Op::Return());
   return builder;
 }
@@ -250,19 +270,23 @@ Builder make_test_buffer_store(ResourceKind kind, bool indexed) {
 
   Type type = kind == ResourceKind::eBufferTyped
     ? BasicType(ScalarType::eF32, 4u)
-    : BasicType(ScalarType::eU32, 2u);
+    : BasicType(ScalarType::eU32, 3u);
 
   SsaDef value = kind == ResourceKind::eBufferTyped
     ? builder.add(Op::CompositeConstruct(type,
         builder.makeConstant(1.0f), builder.makeConstant(2.0f),
         builder.makeConstant(3.0f), builder.makeConstant(4.0f)))
     : builder.add(Op::CompositeConstruct(type,
-        builder.makeConstant(1u), builder.makeConstant(2u)));
+        builder.makeConstant(1u), builder.makeConstant(2u),
+        builder.makeConstant(3u)));
 
   builder.add(Op::BufferStore(descriptor, index0, value,
     kind == ResourceKind::eBufferTyped ? 0u : 4u));
   builder.add(Op::BufferStore(descriptor, index1, value,
     kind == ResourceKind::eBufferTyped ? 0u : 4u));
+
+  if (kind != ResourceKind::eBufferTyped)
+    builder.add(Op::BufferStore(descriptor, index1, builder.makeConstant(6u), 4u));
 
   builder.add(Op::Return());
   return builder;

--- a/tests/api/test_api_resources.cpp
+++ b/tests/api/test_api_resources.cpp
@@ -300,8 +300,23 @@ Builder make_test_buffer_atomic(ResourceKind kind, bool indexed) {
   auto descriptor = emit_buffer_descriptor(builder, entryPoint, kind, true, indexed, true);
   auto index = emit_buffer_load_store_address(builder, entryPoint, kind, true);
 
-  builder.add(Op::BufferAtomic(AtomicOp::eAdd, Type(),
-    descriptor, index, builder.makeConstant(16u)));
+  auto def = builder.add(Op::BufferAtomic(AtomicOp::eLoad, ScalarType::eU32, descriptor, index));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eExchange, ScalarType::eU32, descriptor, index,
+    builder.add(Op::IAdd(ScalarType::eU32, def, builder.makeConstant(10u)))));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eCompareExchange, ScalarType::eU32, descriptor, index,
+    builder.makeConstant(10u), def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eAdd, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eSub, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eSMin, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eSMax, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eUMin, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eUMax, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eAnd, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eOr, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eXor, ScalarType::eU32, descriptor, index, def));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eInc, ScalarType::eU32, descriptor, index));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eDec, ScalarType::eU32, descriptor, index));
+  builder.add(Op::BufferAtomic(AtomicOp::eStore, Type(), descriptor, index, def));
 
   builder.add(Op::Return());
   return builder;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,5 @@
+subdir('api')
+
 test_files = files([
   'test_main.cpp',
 
@@ -14,4 +16,6 @@ executable('test_dxbc_spv', test_files,
   link_with   : [ lib_dxbc_spv ],
   install     : false)
 
-subdir('api')
+executable('test_spirv_lowering', files('test_spirv.cpp'),
+  link_with   : [ lib_dxbc_spv, lib_dxbc_spv_test_api ],
+  install     : false)

--- a/tests/test_spirv.cpp
+++ b/tests/test_spirv.cpp
@@ -1,0 +1,165 @@
+#include <fstream>
+#include <iostream>
+
+#include "./api/test_api.h"
+
+#include "../spirv/spirv_builder.h"
+
+namespace dxbc_spv::tests {
+
+using namespace dxbc_spv::test_api;
+using namespace dxbc_spv::spirv;
+
+struct Options {
+  std::string basePath;
+  std::string testFilter;
+  SpirvBuilder::Options spirv = { };
+  bool overrideRef = false;
+  bool generateNew = false;
+};
+
+std::vector<char> generateSpirv(const ir::Builder& builder, const SpirvBuilder::Options& options) {
+  SpirvBuilder spvBuilder(builder, options);
+  spvBuilder.buildSpirvBinary();
+
+  size_t size = 0u;
+  spvBuilder.getSpirvBinary(size, nullptr);
+
+  std::vector<char> data(size);
+  spvBuilder.getSpirvBinary(size, data.data());
+
+  return data;
+}
+
+
+bool runTest(const Options& options, const NamedTest& test) {
+  const std::string refFile = options.basePath + "/" + test.name + ".ref.spv";
+  const std::string newFile = options.basePath + "/" + test.name + ".new.spv";
+
+  std::ifstream refStream;
+  std::ofstream dstStream;
+
+  /* Load reference binary from file if present */
+  std::vector<char> refBinary;
+
+  if (options.overrideRef) {
+    dstStream = std::ofstream(refFile,
+      std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+
+    if (!dstStream.is_open()) {
+      std::cerr << "Failed to open " << refFile << " for writing." << std::endl;
+      return false;
+    }
+  } else {
+    refStream = std::ifstream(refFile,
+      std::ios_base::in | std::ios_base::binary);
+
+    if (refStream.is_open()) {
+      refStream.seekg(0, std::ios_base::end);
+      refBinary.resize(refStream.tellg());
+      refStream.seekg(0, std::ios_base::beg);
+      refStream.read(refBinary.data(), refBinary.size());
+
+      if (!refStream) {
+        std::cerr << "Failed to read " << refFile << "." << std::endl;
+        return false;
+      }
+    } else if (options.generateNew) {
+      dstStream = std::ofstream(refFile,
+        std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+
+      if (!dstStream.is_open()) {
+        std::cerr << "Failed to open " << refFile << " for writing." << std::endl;
+        return false;
+      }
+    } else {
+      std::cerr << "Failed to open " << refFile << " for reading." << std::endl;
+      return true;
+    }
+  }
+
+  /* Generate SPIR-V binary for lowering test */
+  std::vector<char> newBinary = generateSpirv(test.builder, options.spirv);
+
+  /* Compare to reference and write as necessary */
+  bool writeDstFile = true;
+
+  if (!refBinary.empty()) {
+    bool isSame = false;
+
+    if (newBinary.size() == refBinary.size())
+      isSame = !std::memcmp(refBinary.data(), newBinary.data(), newBinary.size());
+
+    if (isSame)
+      writeDstFile = false;
+    else
+      std::cout << refFile << " has changed" << std::endl;
+  }
+
+  if (writeDstFile) {
+    if (!dstStream.is_open()) {
+      dstStream = std::ofstream(newFile,
+        std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+
+      if (!dstStream.is_open()) {
+        std::cerr << "Failed to open " << newFile << " for writing." << std::endl;
+        return false;
+      }
+    }
+
+    dstStream.write(newBinary.data(), newBinary.size());
+  }
+
+  return true;
+}
+
+
+void runTests(const Options& options, const std::vector<NamedTest>& tests) {
+  for (const auto& test : tests)
+    runTest(options, test);
+}
+
+
+void run(const Options& options) {
+  const char* filter = !options.testFilter.empty() ? options.testFilter.c_str() : nullptr;
+  runTests(options, test_api::enumerateTests(filter));
+}
+
+}
+
+
+void printHelp(const char* name) {
+  std::cerr << "Usage: " << name << " file_path [--filter name] [--regen] [--gen-new] [--enable-nv-access-chains]" << std::endl;
+}
+
+
+int main(int argc, char** argv) {
+  if (argc <= 1 || std::string(argv[1u]) == "--help") {
+    printHelp(argv[0]);
+    return 0;
+  }
+
+  dxbc_spv::tests::Options options;
+  options.basePath = argv[1u];
+  options.spirv.includeDebugNames = true;
+
+  for (int i = 2u; i < argc; i++) {
+    std::string arg = argv[i];
+
+    if (arg == "--regen") {
+      options.overrideRef = true;
+    } else if (arg == "--gen-new") {
+      options.generateNew = true;
+    } else if (arg == "--enable-nv-raw-access-chains") {
+      options.spirv.nvRawAccessChains = true;
+    } else if (arg == "--filter" && i + 1 < argc) {
+      options.testFilter = argv[++i];
+    } else {
+      std::cerr << "Unrecognized option: " << arg << std::endl;
+      return 1;
+    }
+  }
+
+  dxbc_spv::tests::run(options);
+  return 0;
+}


### PR DESCRIPTION
Currently based on #4 and implements enough to generate valid SPIR-V for the vertex shader I/O tests.