### PR TITLE
Test, implement and fix arithmetic stuff

### DIFF
--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -773,9 +773,10 @@ std::ostream& operator << (std::ostream& os, const OpCode& opCode) {
     case OpCode::eISub: return os << "ISub";
     case OpCode::eISubBorrow: return os << "ISubBorrow";
     case OpCode::eINeg: return os << "INeg";
+    case OpCode::eIAbs: return os << "IAbs";
     case OpCode::eIMul: return os << "IMul";
-    case OpCode::eSDiv: return os << "SDiv";
     case OpCode::eUDiv: return os << "UDiv";
+    case OpCode::eUMod: return os << "UMod";
     case OpCode::eSMin: return os << "SMin";
     case OpCode::eSMax: return os << "SMax";
     case OpCode::eSClamp: return os << "SClamp";

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -777,6 +777,9 @@ std::ostream& operator << (std::ostream& os, const OpCode& opCode) {
     case OpCode::eUMax: return os << "UMax";
     case OpCode::eUClamp: return os << "UClamp";
     case OpCode::eUMSad: return os << "UMSad";
+    case OpCode::eSMulExtended: return os << "SMulExtended";
+    case OpCode::eUMulExtended: return os << "UMulExtended";
+
   }
 
   return os << "OpCode(" << std::dec << uint32_t(opCode) << ")";

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -715,8 +715,12 @@ std::ostream& operator << (std::ostream& os, const OpCode& opCode) {
     case OpCode::eIEq: return os << "IEq";
     case OpCode::eINe: return os << "INe";
     case OpCode::eSLt: return os << "SLt";
+    case OpCode::eSLe: return os << "SLe";
+    case OpCode::eSGt: return os << "SGt";
     case OpCode::eSGe: return os << "SGe";
     case OpCode::eULt: return os << "ULt";
+    case OpCode::eULe: return os << "ULe";
+    case OpCode::eUGt: return os << "UGt";
     case OpCode::eUGe: return os << "UGe";
     case OpCode::eBAnd: return os << "BAnd";
     case OpCode::eBOr: return os << "BOr";

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -656,6 +656,8 @@ std::ostream& operator << (std::ostream& os, const OpCode& opCode) {
     case OpCode::eConvertFtoI: return os << "ConvertFtoI";
     case OpCode::eConvertItoF: return os << "ConvertItoF";
     case OpCode::eConvertItoI: return os << "ConvertItoI";
+    case OpCode::eConvertF32toPackedF16: return os << "ConvertF32toPackedF16";
+    case OpCode::eConvertPackedF16toF32: return os << "ConvertPackedF16toF32";
     case OpCode::eCast: return os << "Cast";
     case OpCode::eConsumeAs: return os << "ConsumeAs";
     case OpCode::eCompositeInsert: return os << "CompositeInsert";

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -936,9 +936,13 @@ enum class OpCode : uint16_t {
   eIEq                          = 583u,
   eINe                          = 584u,
   eSLt                          = 585u,
-  eSGe                          = 586u,
-  eULt                          = 587u,
-  eUGe                          = 588u,
+  eSLe                          = 586u,
+  eSGt                          = 587u,
+  eSGe                          = 588u,
+  eULt                          = 589u,
+  eULe                          = 590u,
+  eUGt                          = 591u,
+  eUGe                          = 592u,
 
   eBAnd                         = 608u,
   eBOr                          = 609u,
@@ -2094,6 +2098,18 @@ public:
       .addOperand(Operand(b));
   }
 
+  static Op SLe(SsaDef a, SsaDef b) {
+    return Op(OpCode::eSLe, ScalarType::eBool)
+      .addOperand(Operand(a))
+      .addOperand(Operand(b));
+  }
+
+  static Op SGt(SsaDef a, SsaDef b) {
+    return Op(OpCode::eSGt, ScalarType::eBool)
+      .addOperand(Operand(a))
+      .addOperand(Operand(b));
+  }
+
   static Op SGe(SsaDef a, SsaDef b) {
     return Op(OpCode::eSGe, ScalarType::eBool)
       .addOperand(Operand(a))
@@ -2102,6 +2118,18 @@ public:
 
   static Op ULt(SsaDef a, SsaDef b) {
     return Op(OpCode::eULt, ScalarType::eBool)
+      .addOperand(Operand(a))
+      .addOperand(Operand(b));
+  }
+
+  static Op ULe(SsaDef a, SsaDef b) {
+    return Op(OpCode::eULe, ScalarType::eBool)
+      .addOperand(Operand(a))
+      .addOperand(Operand(b));
+  }
+
+  static Op UGt(SsaDef a, SsaDef b) {
+    return Op(OpCode::eUGt, ScalarType::eBool)
       .addOperand(Operand(a))
       .addOperand(Operand(b));
   }

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -1003,6 +1003,8 @@ enum class OpCode : uint16_t {
   eUMax                         = 748u,
   eUClamp                       = 749u,
   eUMSad                        = 750u,
+  eSMulExtended                 = 751u,
+  eUMulExtended                 = 752u,
 
   Count
 };

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -1878,30 +1878,30 @@ public:
   }
 
   template<typename... T>
-  static Op LdsAtomic(AtomicOp op, Type type, SsaDef decl, SsaDef address, T... args) {
+  static Op LdsAtomic(AtomicOp op, Type type, SsaDef decl, SsaDef address, SsaDef operands) {
     return Op(OpCode::eLdsAtomic, type)
       .addOperand(Operand(decl))
       .addOperand(Operand(address))
-      .addOperands(Operand(SsaDef(args))...)
+      .addOperand(Operand(operands))
       .addOperand(Operand(op));
   }
 
   template<typename... T>
-  static Op BufferAtomic(AtomicOp op, Type type, SsaDef descriptor, SsaDef address, T... args) {
+  static Op BufferAtomic(AtomicOp op, Type type, SsaDef descriptor, SsaDef address, SsaDef operands) {
     return Op(OpCode::eBufferAtomic, type)
       .addOperand(Operand(descriptor))
       .addOperand(Operand(address))
-      .addOperands(Operand(SsaDef(args))...)
+      .addOperand(Operand(operands))
       .addOperand(Operand(op));
   }
 
   template<typename... T>
-  static Op ImageAtomic(AtomicOp op, Type type, SsaDef descriptor, SsaDef layer, SsaDef coord, T... args) {
+  static Op ImageAtomic(AtomicOp op, Type type, SsaDef descriptor, SsaDef layer, SsaDef coord, SsaDef operands) {
     return Op(OpCode::eImageAtomic, type)
       .addOperand(Operand(descriptor))
       .addOperand(Operand(layer))
       .addOperand(Operand(coord))
-      .addOperands(Operand(SsaDef(args))...)
+      .addOperand(Operand(operands))
       .addOperand(Operand(op));
   }
 
@@ -1913,11 +1913,11 @@ public:
   }
 
   template<typename... T>
-  static Op MemoryAtomic(AtomicOp op, Type type, SsaDef pointer, SsaDef address, T... args) {
+  static Op MemoryAtomic(AtomicOp op, Type type, SsaDef pointer, SsaDef address, SsaDef operands) {
     return Op(OpCode::eMemoryAtomic, type)
       .addOperand(Operand(pointer))
       .addOperand(Operand(address))
-      .addOperands(Operand(SsaDef(args))...)
+      .addOperand(Operand(operands))
       .addOperand(Operand(op));
   }
 

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -998,19 +998,20 @@ enum class OpCode : uint16_t {
   eIAddCarry                    = 737u,
   eISub                         = 738u,
   eISubBorrow                   = 739u,
-  eINeg                         = 740u,
-  eIMul                         = 741u,
-  eSDiv                         = 742u,
-  eUDiv                         = 743u,
-  eSMin                         = 744u,
-  eSMax                         = 745u,
-  eSClamp                       = 746u,
-  eUMin                         = 747u,
-  eUMax                         = 748u,
-  eUClamp                       = 749u,
-  eUMSad                        = 750u,
-  eSMulExtended                 = 751u,
-  eUMulExtended                 = 752u,
+  eIAbs                         = 740u,
+  eINeg                         = 741u,
+  eIMul                         = 742u,
+  eSMulExtended                 = 743u,
+  eUMulExtended                 = 744u,
+  eUDiv                         = 745u,
+  eUMod                         = 746u,
+  eSMin                         = 747u,
+  eSMax                         = 748u,
+  eSClamp                       = 749u,
+  eUMin                         = 750u,
+  eUMax                         = 751u,
+  eUClamp                       = 752u,
+  eUMSad                        = 753u,
 
   Count
 };
@@ -2442,14 +2443,14 @@ public:
       .addOperand(Operand(b));
   }
 
-  static Op SDiv(Type type, SsaDef a, SsaDef b) {
-    return Op(OpCode::eSDiv, type)
+  static Op UDiv(Type type, SsaDef a, SsaDef b) {
+    return Op(OpCode::eUDiv, type)
       .addOperand(Operand(a))
       .addOperand(Operand(b));
   }
 
-  static Op UDiv(Type type, SsaDef a, SsaDef b) {
-    return Op(OpCode::eUDiv, type)
+  static Op UMod(Type type, SsaDef a, SsaDef b) {
+    return Op(OpCode::eUMod, type)
       .addOperand(Operand(a))
       .addOperand(Operand(b));
   }

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -865,8 +865,10 @@ enum class OpCode : uint16_t {
   eConvertFtoI                  = 193u,
   eConvertItoF                  = 194u,
   eConvertItoI                  = 195u,
-  eCast                         = 196u,
-  eConsumeAs                    = 197u,
+  eConvertF32toPackedF16        = 196u,
+  eConvertPackedF16toF32        = 197u,
+  eCast                         = 198u,
+  eConsumeAs                    = 199u,
 
   eCompositeInsert              = 224u,
   eCompositeExtract             = 225u,
@@ -1712,6 +1714,16 @@ public:
 
   static Op ConvertItoI(Type type, SsaDef value) {
     return Op(OpCode::eConvertItoI, type)
+      .addOperand(Operand(value));
+  }
+
+  static Op ConvertF32toPackedF16(SsaDef value) {
+    return Op(OpCode::eConvertF32toPackedF16, ScalarType::eU32)
+      .addOperand(Operand(value));
+  }
+
+  static Op ConvertPackedF16toF32(SsaDef value) {
+    return Op(OpCode::eConvertPackedF16toF32, BasicType(ScalarType::eF32, 2u))
       .addOperand(Operand(value));
   }
 

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -552,10 +552,11 @@ Note that the `FindMsb` instructions follow SPIR-V semantics rather than D3D sem
 | `IAddCarry`               | `vec2<u32>`  | `%a`         | `%b`      |           |
 | `ISub`                    | integer      | `%a`         | `%b`      |           |
 | `ISubBorrow`              | `vec2<u32>`  | `%a`         | `%b`      |           |
+| `IAbs`                    | integer      | `%a`         |           |           |
 | `INeg`                    | integer      | `%a`         |           |           |
 | `IMul`                    | integer      | `%a`         | `%b`      |           |
-| `SDiv`                    | integer      | `%a`         | `%b`      |           |
 | `UDiv`                    | integer      | `%a`         | `%b`      |           |
+| `UMod`                    | integer      | `%a`         | `%b`      |           |
 | `SMin`                    | integer      | `%a`         | `%b`      |           |
 | `SMax`                    | integer      | `%a`         | `%b`      |           |
 | `SClamp`                  | integer      | `%a`         | `%b`      | `%c`      |

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -511,11 +511,11 @@ Maps boolean values to values of any other type.
 | `FCos`                    | `f32`        | `%a`         |         |       |
 
 Note that `FDot*` instructions takes vector arguments and returns a scalar. This instruction
-should be lowered to a sequence of `FMul*` and `FMad*` instructions.
+**must** be lowered to a sequence of `FMul*` and `FMad*` instructions.
 
 The `mode` parameter for `FRound` is a constant enum `ir::RoundMode`.
 
-The `*Legacy` instructions follow D3D9 rules w.r.t. multiplication.
+The `*Legacy` instructions follow D3D9 rules w.r.t. multiplication by zero and **must** be lowered.
 
 ### Bitwise instructions
 | `ir::OpCode`              | Return type  | Arguments... |           |           |          |

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -538,9 +538,9 @@ Note that the `FindMsb` instructions follow SPIR-V semantics rather than D3D sem
 | `ir::OpCode`              | Return type  | Arguments... |           |           |
 |---------------------------|--------------|--------------|-----------|-----------|
 | `IAdd`                    | integer      | `%a`         | `%b`      |           |
-| `IAddCarry`               | `vec2<u*>`   | `%a`         | `%b`      |           |
+| `IAddCarry`               | `vec2<u32>`  | `%a`         | `%b`      |           |
 | `ISub`                    | integer      | `%a`         | `%b`      |           |
-| `ISubBorrow`              | `vec2<u*>`   | `%a`         | `%b`      |           |
+| `ISubBorrow`              | `vec2<u32>`  | `%a`         | `%b`      |           |
 | `INeg`                    | integer      | `%a`         |           |           |
 | `IMul`                    | integer      | `%a`         | `%b`      |           |
 | `SDiv`                    | integer      | `%a`         | `%b`      |           |
@@ -552,6 +552,11 @@ Note that the `FindMsb` instructions follow SPIR-V semantics rather than D3D sem
 | `UMax`                    | integer      | `%a`         | `%b`      |           |
 | `UClamp`                  | integer      | `%a`         | `%b`      | `%c`      |
 | `UMsad`                   | integer      | `%ref`       | `%src`    | `%accum`  |
+| `SMulExtended`            | `vec2<i32>`  | `%a`         | `%b`      |           |
+| `UMulExtended`            | `vec2<u32>`  | `%a`         | `%b`      |           |
+
+The instructions `IAddCarry`, `ISubBorrow` and `*MulExtended` return a two-component vector with the low bits in the first
+component, and the high bits (carry / borrow bits) in the second component. These instructions only support 32-bit types.
 
 ## Serialization
 The custom IR can be serialized for in-memory storage as a sequence of tokens that use variable-length encoding to save memory.

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -441,7 +441,7 @@ stage, barriers with a wider execution scope are only meaningful in hull and com
 | `RovScopedLockEnd`        | `void`      |              |                         |
 
 ### Comparison instructions
-Component-wise comparisons that return a boolean vector.
+Component-wise comparisons that return a boolean. Operands must be scalar.
 
 | `ir::OpCode`              | Return type | Arguments... |      |
 |---------------------------|-------------|--------------|------|

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -301,13 +301,17 @@ The `ir::AtomicOp` parameter is a literal enum value, thus the last parameter.
 The `%layer` parameter is `null` for non-arrayed image types.
 
 #### Operations
+Unless otherwise noted, the `%operand` parameter is a scalar integer whose type matches that of
+the return type and resource type exactly.
+
 - `Load`: Atomically loads a value. This instruction is generated when an atomic instruction has
-  no side effects. Must not have a `void` return type.
+  no side effects. Must not have a `void` return type. `%operand` will be `null`.
 - `Store`: Atomically stores a value. This instruction is generated when the result of an atomic
   exchange instruction goes unused.
 - `Inc` and `Dec` are equivalent to `Add` or `Sub` with a constant value of `1`, respectively.
-- `CompareExchange` has two operands: The value to compare to first, and the value to store on
-  success second.
+  `%operand` will be `null`.
+- `CompareExchange` takes a `vec2<u32/i32>` as an operand: The value to compare to first, and the
+  value to store on success second.
 
 ### Image instructions
 | `ir::OpCode`         | Return type      | Arguments...  |                   |             |              |              |             |              |          |           |       |             |

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -109,9 +109,9 @@ All operands bar the `%EntryPoint` operand are literal constants.
 If the result type and source type are the same, the conversion operation is a no-op and will be removed by a lowering pass.
 
 Semantics are as follows:
-- `ConvertFtoF` converts between float types of a different width. If the result type is smaller than the
-  source type, round-to-zero semantics are required but no specific denorm behaviour is specified.
-- `ConvertFToI` is a saturating conversion from a float type to a signed or unsigned integer, with round-to-zero semantics.
+- `ConvertFtoF` converts between float types of a different width. For conversions from `f64`, round-even semantics are required
+  but denorms may or may not get flushed.
+- `ConvertFToI` is a conversion from a float type to a signed or unsigned integer, with round-to-zero semantics.
 - `ConvertIToF` is a value-preserving conversion from a signed or unsigned integer to any float type with round-even semantics.
 - `ConvertItoI` converts between integer types of different size. If the result type is larger than the source and the source
   is signed, it will be sign-extended, otherwise it will be zero-extended. If the result type is smaller, excess bits are discarded.

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -455,8 +455,12 @@ Component-wise comparisons that return a boolean vector.
 | `IEq`                     | `bool`      | `%a`         | `%b` |
 | `INe`                     | `bool`      | `%a`         | `%b` |
 | `SLt`                     | `bool`      | `%a`         | `%b` |
+| `SLe`                     | `bool`      | `%a`         | `%b` |
+| `SGt`                     | `bool`      | `%a`         | `%b` |
 | `SGe`                     | `bool`      | `%a`         | `%b` |
 | `ULt`                     | `bool`      | `%a`         | `%b` |
+| `ULe`                     | `bool`      | `%a`         | `%b` |
+| `UGt`                     | `bool`      | `%a`         | `%b` |
 | `UGe`                     | `bool`      | `%a`         | `%b` |
 
 With the exception of `FNe`, all float comparisons are ordered.

--- a/ir/ir.md
+++ b/ir/ir.md
@@ -95,14 +95,16 @@ These instructions provide additional information that may affect the execution 
 All operands bar the `%EntryPoint` operand are literal constants.
 
 ### Type conversion instructions
-| `ir::OpCode`         | Return type      | Argument         |
-|----------------------|------------------|------------------|
-| `ConvertFtoF`        | any              | `%value`         |
-| `ConvertFtoI`        | any              | `%value`         |
-| `ConvertItoF`        | any              | `%value`         |
-| `ConvertItoI`        | any              | `%value`         |
-| `Cast`               | any              | `%value`         |
-| `ConsumeAs`          | any              | `%value`         |
+| `ir::OpCode`            | Return type      | Argument         |
+|-------------------------|------------------|------------------|
+| `ConvertFtoF`           | any              | `%value`         |
+| `ConvertFtoI`           | any              | `%value`         |
+| `ConvertItoF`           | any              | `%value`         |
+| `ConvertItoI`           | any              | `%value`         |
+| `ConvertF32toPackedF16` | `u32`            | `%value`         |
+| `ConvertPackedF16toF32` | `vec2<f32>`      | `%value`         |
+| `Cast`                  | any              | `%value`         |
+| `ConsumeAs`             | any              | `%value`         |
 
 If the result type and source type are the same, the conversion operation is a no-op and will be removed by a lowering pass.
 
@@ -114,6 +116,11 @@ Semantics are as follows:
 - `ConvertItoI` converts between integer types of different size. If the result type is larger than the source and the source
   is signed, it will be sign-extended, otherwise it will be zero-extended. If the result type is smaller, excess bits are discarded.
   If the two types only differ in signedness, this instruction is identical in behaviour to `Cast` and will be lowered to it.
+- `ConvertF32toPackedF16` takes a vector of `f32`, performs a conversion to `f16`, and packs both into a single unsigned integer with
+  the first component of the vector stored in the lower 16 bits of the result. This instruction does not require hardware support
+  for 16-bit floating point arithmetic. The float conversion must use round-to-zero semantics.
+- `ConvertPackedF16toF32` takes a single `u32` as two packed `f16` and converts them to an `f32` vector. This instruction does not require
+  hardware support for 16-bit floating point arithmetic.
 - `Cast` is a bit-pattern preserving cast between different types that must have the same bit size. Vector types are allowed.
 
 `ConsumeAs` is a helper instruction that is used to resolve and back-propagate expression types in an untyped IR, and will be

--- a/ir/ir_validation.cpp
+++ b/ir/ir_validation.cpp
@@ -640,7 +640,7 @@ bool Validator::validateImageOps(std::ostream& str) const {
         mip = SsaDef(op->getOperand(1u));
 
         expectedType = Type()
-          .addStructMember(BasicType(ScalarType::eU32, resourceCoordComponentCount(kind)))
+          .addStructMember(BasicType(ScalarType::eU32, resourceDimensions(kind)))
           .addStructMember(ScalarType::eU32);
       } break;
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -354,13 +354,8 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eInterpolateAtOffset:
     case ir::OpCode::eRovScopedLockBegin:
     case ir::OpCode::eRovScopedLockEnd:
-    case ir::OpCode::eFDot:
-    case ir::OpCode::eFDotLegacy:
-    case ir::OpCode::eFMulLegacy:
-    case ir::OpCode::eFMadLegacy:
     case ir::OpCode::eIAddCarry:
     case ir::OpCode::eISubBorrow:
-    case ir::OpCode::eUMSad:
     case ir::OpCode::eSMulExtended:
     case ir::OpCode::eUMulExtended:
       /* TODO implement */
@@ -385,8 +380,14 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eScopedSwitchBreak:
     case ir::OpCode::eScopedEndSwitch:
     case ir::OpCode::eConsumeAs:
+    case ir::OpCode::eFDot:
+    case ir::OpCode::eFDotLegacy:
+    case ir::OpCode::eFMulLegacy:
+    case ir::OpCode::eFMadLegacy:
+    case ir::OpCode::eUMSad:
     case ir::OpCode::Count:
       /* Invalid opcodes */
+      std::cerr << "Invalid opcode " << op.getOpCode() << std::endl;
       break;
   }
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -315,6 +315,8 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eIFindLsb:
     case ir::OpCode::eSFindMsb:
     case ir::OpCode::eUFindMsb:
+    case ir::OpCode::eConvertF32toPackedF16:
+    case ir::OpCode::eConvertPackedF16toF32:
       return emitExtendedGlslArithmetic(op);
 
     case ir::OpCode::eFRcp:
@@ -2449,6 +2451,8 @@ void SpirvBuilder::emitExtendedGlslArithmetic(const ir::Op& op) {
       case ir::OpCode::eIFindLsb: return GLSLstd450FindILsb;
       case ir::OpCode::eSFindMsb: return GLSLstd450FindSMsb;
       case ir::OpCode::eUFindMsb: return GLSLstd450FindUMsb;
+      case ir::OpCode::eConvertF32toPackedF16: return GLSLstd450PackHalf2x16;
+      case ir::OpCode::eConvertPackedF16toF32: return GLSLstd450UnpackHalf2x16;
       default: dxbc_spv_unreachable();
     }
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -1059,17 +1059,12 @@ void SpirvBuilder::emitBufferStore(const ir::Op& op) {
       storeIds.push_back(std::make_pair(accessChainId, getIdForDef(valueOp.getDef())));
     } else {
       /* Extract scalars from vector and scalarize access chains */
-      auto valueId = getIdForDef(valueOp.getDef());
-
       for (uint32_t i = 0u; i < accessType.getBaseType(0u).getVectorSize(); i++) {
         auto accessChainId = emitAccessChain(spv::StorageClassStorageBuffer, dclOp.getType(),
           getIdForDef(descriptorOp.getDef()), addressDef, i, hasWrapperStruct);
-        auto componentId = allocId();
 
-        pushOp(m_code, spv::OpCompositeExtract,
-          getIdForType(addressedType), componentId, valueId, i);
-
-        storeIds.push_back(std::make_pair(accessChainId, componentId));
+        storeIds.push_back(std::make_pair(accessChainId,
+          emitExtractComponent(valueOp.getDef(), i)));
       }
     }
 

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -351,6 +351,8 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eUMax:
     case ir::OpCode::eUClamp:
     case ir::OpCode::eUMSad:
+    case ir::OpCode::eSMulExtended:
+    case ir::OpCode::eUMulExtended:
       /* TODO implement */
       std::cerr << "Unimplemented opcode " << op.getOpCode() << std::endl;
       break;

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -290,10 +290,11 @@ void SpirvBuilder::emitInstruction(const ir::Op& op) {
     case ir::OpCode::eISub:
     case ir::OpCode::eINeg:
     case ir::OpCode::eIMul:
-    case ir::OpCode::eSDiv:
     case ir::OpCode::eUDiv:
+    case ir::OpCode::eUMod:
       return emitSimpleArithmetic(op);
 
+    case ir::OpCode::eIAbs:
     case ir::OpCode::eFAbs:
     case ir::OpCode::eFMad:
     case ir::OpCode::eFFract:
@@ -2403,8 +2404,8 @@ void SpirvBuilder::emitSimpleArithmetic(const ir::Op& op) {
       case ir::OpCode::eISub:         return spv::OpISub;
       case ir::OpCode::eINeg:         return spv::OpSNegate;
       case ir::OpCode::eIMul:         return spv::OpIMul;
-      case ir::OpCode::eSDiv:         return spv::OpSDiv;
       case ir::OpCode::eUDiv:         return spv::OpUDiv;
+      case ir::OpCode::eUMod:         return spv::OpUMod;
 
       default:
         dxbc_spv_unreachable();
@@ -2430,6 +2431,7 @@ void SpirvBuilder::emitSimpleArithmetic(const ir::Op& op) {
 void SpirvBuilder::emitExtendedGlslArithmetic(const ir::Op& op) {
   auto extOp = [&] {
     switch (op.getOpCode()) {
+      case ir::OpCode::eIAbs: return GLSLstd450SAbs;
       case ir::OpCode::eFAbs: return GLSLstd450FAbs;
       case ir::OpCode::eFMad: return GLSLstd450Fma;
       case ir::OpCode::eFFract: return GLSLstd450Fract;

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -230,6 +230,8 @@ private:
 
   void emitFRound(const ir::Op& op);
 
+  void emitInterpolation(const ir::Op& op);
+
   void emitSetCsWorkgroupSize(const ir::Op& op);
 
   uint32_t emitExtractComponent(ir::SsaDef vectorDef, uint32_t index);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -222,6 +222,12 @@ private:
 
   void emitSimpleArithmetic(const ir::Op& op);
 
+  void emitExtendedGlslArithmetic(const ir::Op& op);
+
+  void emitFRcp(const ir::Op& op);
+
+  void emitFRound(const ir::Op& op);
+
   void emitSetCsWorkgroupSize(const ir::Op& op);
 
   uint32_t importGlslExt();

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -224,6 +224,8 @@ private:
 
   void emitExtendedGlslArithmetic(const ir::Op& op);
 
+  void emitExtendedIntArithmetic(const ir::Op& op);
+
   void emitFRcp(const ir::Op& op);
 
   void emitFRound(const ir::Op& op);

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -170,7 +170,7 @@ private:
 
   void emitDerivative(const ir::Op& op);
 
-  void emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t operandIndex,
+  void emitAtomic(const ir::Op& op, const ir::Type& type, ir::SsaDef operandDef,
       uint32_t ptrId, spv::Scope scope, spv::MemorySemanticsMask memoryTypes);
 
   void emitFunction(const ir::Op& op);
@@ -231,6 +231,8 @@ private:
   void emitFRound(const ir::Op& op);
 
   void emitSetCsWorkgroupSize(const ir::Op& op);
+
+  uint32_t emitExtractComponent(ir::SsaDef vectorDef, uint32_t index);
 
   uint32_t importGlslExt();
 

--- a/tests/api/meson.build
+++ b/tests/api/meson.build
@@ -1,5 +1,6 @@
 test_api_files = files([
   'test_api.cpp',
+  'test_api_arithmetic.cpp',
   'test_api_io.cpp',
   'test_api_resources.cpp',
 ])

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -217,6 +217,13 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_arithmetic_fp16_packing);
   ADD_TEST(test_arithmetic_fp16_packing_legacy);
 
+  ADD_TEST(test_arithmetic_sint32);
+  ADD_TEST(test_arithmetic_uint32);
+  ADD_TEST(test_arithmetic_sint16_scalar);
+  ADD_TEST(test_arithmetic_sint16_vector);
+  ADD_TEST(test_arithmetic_uint16_scalar);
+  ADD_TEST(test_arithmetic_uint16_vector);
+
 return result;
 #undef ADD_TEST
 }

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -209,10 +209,13 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
 
   ADD_TEST(test_arithmetic_fp64);
   ADD_TEST(test_arithmetic_fp64_compare);
+  ADD_TEST(test_arithmetic_fp64_packing);
 
   ADD_TEST(test_arithmetic_fp16_scalar);
   ADD_TEST(test_arithmetic_fp16_vector);
   ADD_TEST(test_arithmetic_fp16_compare);
+  ADD_TEST(test_arithmetic_fp16_packing);
+  ADD_TEST(test_arithmetic_fp16_packing_legacy);
 
 return result;
 #undef ADD_TEST

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -30,6 +30,10 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_io_vs_layer);
   ADD_TEST(test_io_vs_viewport);
 
+  ADD_TEST(test_io_ps_interpolate_centroid);
+  ADD_TEST(test_io_ps_interpolate_sample);
+  ADD_TEST(test_io_ps_interpolate_offset);
+
   ADD_TEST(test_resources_cbv);
   ADD_TEST(test_resources_cbv_dynamic);
   ADD_TEST(test_resources_cbv_indexed);

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -205,11 +205,14 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_arithmetic_fp32);
   ADD_TEST(test_arithmetic_fp32_precise);
   ADD_TEST(test_arithmetic_fp32_special);
+  ADD_TEST(test_arithmetic_fp32_compare);
 
   ADD_TEST(test_arithmetic_fp64);
+  ADD_TEST(test_arithmetic_fp64_compare);
 
   ADD_TEST(test_arithmetic_fp16_scalar);
   ADD_TEST(test_arithmetic_fp16_vector);
+  ADD_TEST(test_arithmetic_fp16_compare);
 
 return result;
 #undef ADD_TEST

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -1,4 +1,5 @@
 #include "test_api.h"
+#include "test_api_arithmetic.h"
 #include "test_api_io.h"
 #include "test_api_resources.h"
 
@@ -200,6 +201,15 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
 
   ADD_TEST(test_resource_uav_buffer_load_sparse_feedback);
   ADD_TEST(test_resource_uav_image_load_sparse_feedback);
+
+  ADD_TEST(test_arithmetic_fp32);
+  ADD_TEST(test_arithmetic_fp32_precise);
+  ADD_TEST(test_arithmetic_fp32_special);
+
+  ADD_TEST(test_arithmetic_fp64);
+
+  ADD_TEST(test_arithmetic_fp16_scalar);
+  ADD_TEST(test_arithmetic_fp16_vector);
 
 return result;
 #undef ADD_TEST

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -229,6 +229,8 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_arithmetic_sint16_compare);
   ADD_TEST(test_arithmetic_uint16_compare);
 
+  ADD_TEST(test_arithmetic_int_extended);
+
   ADD_TEST(test_arithmetic_bool);
 
 return result;

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -224,6 +224,11 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_arithmetic_uint16_scalar);
   ADD_TEST(test_arithmetic_uint16_vector);
 
+  ADD_TEST(test_arithmetic_sint32_compare);
+  ADD_TEST(test_arithmetic_uint32_compare);
+  ADD_TEST(test_arithmetic_sint16_compare);
+  ADD_TEST(test_arithmetic_uint16_compare);
+
 return result;
 #undef ADD_TEST
 }

--- a/tests/api/test_api.cpp
+++ b/tests/api/test_api.cpp
@@ -229,6 +229,8 @@ std::vector<NamedTest> enumerateTests(const char* filter) {
   ADD_TEST(test_arithmetic_sint16_compare);
   ADD_TEST(test_arithmetic_uint16_compare);
 
+  ADD_TEST(test_arithmetic_bool);
+
 return result;
 #undef ADD_TEST
 }

--- a/tests/api/test_api_arithmetic.cpp
+++ b/tests/api/test_api_arithmetic.cpp
@@ -119,6 +119,63 @@ Builder make_test_float_arithmetic(BasicType type, bool precise) {
 }
 
 
+Builder make_test_float_compare(ScalarType type) {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eCompute);
+  builder.add(Op::SetCsWorkgroupSize(entryPoint, 1u, 1u, 1u));
+  builder.add(Op::Label());
+
+  auto srvType = Type(ScalarType::eF32).addArrayDimension(1u).addArrayDimension(0u);
+  auto uavType = Type(ScalarType::eU32).addArrayDimension(1u).addArrayDimension(0u);
+
+  auto srv = builder.add(Op::DclSrv(srvType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured));
+  auto uav = builder.add(Op::DclUav(uavType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured, UavFlag::eWriteOnly));
+
+  auto srvDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eSrv, srv, builder.makeConstant(0u)));
+  auto uavDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eUav, uav, builder.makeConstant(0u)));
+
+  static const std::vector<std::pair<ir::OpCode, uint32_t>> tests = {
+    { ir::OpCode::eFEq, 2u },
+    { ir::OpCode::eFNe, 2u },
+    { ir::OpCode::eFLt, 2u },
+    { ir::OpCode::eFLe, 2u },
+    { ir::OpCode::eFGt, 2u },
+    { ir::OpCode::eFGe, 2u },
+    { ir::OpCode::eFIsNan, 1u },
+  };
+
+  /* Reuse the same operands for all ops */
+  std::array<SsaDef, 2u> operands;
+
+  for (uint32_t i = 0u; i < operands.size(); i++) {
+    auto indexDef = builder.makeConstant(i, 0u);
+    operands[i] = builder.add(Op::BufferLoad(ScalarType::eF32, srvDescriptor, indexDef, 4u));
+
+    if (type != ScalarType::eF32)
+      operands[i] = builder.add(Op::ConvertFtoF(type, operands[i]));
+  }
+
+  uint32_t uavIndex = 0u;
+
+  for (const auto& e : tests) {
+    Op op(e.first, ScalarType::eBool);
+
+    for (uint32_t i = 0u; i < e.second; i++)
+      op.addOperand(Operand(operands.at(i)));
+
+    auto resultDef = builder.add(std::move(op));
+    resultDef = builder.add(Op::Select(ScalarType::eU32, resultDef,
+      builder.makeConstant(1u), builder.makeConstant(0u)));
+
+    auto indexDef = builder.makeConstant(uavIndex++, 0u);
+    builder.add(Op::BufferStore(uavDescriptor, indexDef, resultDef, 4u));
+  }
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+
 Builder test_arithmetic_fp32() {
   return make_test_float_arithmetic(ScalarType::eF32, false);
 }
@@ -161,8 +218,16 @@ Builder test_arithmetic_fp32_special() {
   return builder;
 }
 
+Builder test_arithmetic_fp32_compare() {
+  return make_test_float_compare(ScalarType::eF32);
+}
+
 Builder test_arithmetic_fp64() {
   return make_test_float_arithmetic(ScalarType::eF64, false);
+}
+
+Builder test_arithmetic_fp64_compare() {
+  return make_test_float_compare(ScalarType::eF64);
 }
 
 Builder test_arithmetic_fp16_scalar() {
@@ -171,6 +236,10 @@ Builder test_arithmetic_fp16_scalar() {
 
 Builder test_arithmetic_fp16_vector() {
   return make_test_float_arithmetic(BasicType(ScalarType::eF16, 2u), false);
+}
+
+Builder test_arithmetic_fp16_compare() {
+  return make_test_float_compare(ScalarType::eF16);
 }
 
 }

--- a/tests/api/test_api_arithmetic.cpp
+++ b/tests/api/test_api_arithmetic.cpp
@@ -1,0 +1,176 @@
+#include "test_api_arithmetic.h"
+
+namespace dxbc_spv::test_api {
+
+struct ArithmeticTest {
+  ir::OpCode opCode = ir::OpCode();
+  uint32_t operandCount = 0u;
+  ir::RoundMode roundMode = { };
+};
+
+Builder make_test_float_arithmetic(BasicType type, bool precise) {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eCompute);
+  builder.add(Op::SetCsWorkgroupSize(entryPoint, 1u, 1u, 1u));
+  builder.add(Op::Label());
+
+  auto bufType = Type(ScalarType::eF32).addArrayDimension(type.getVectorSize()).addArrayDimension(0u);
+  auto srv = builder.add(Op::DclSrv(bufType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured));
+  auto uav = builder.add(Op::DclUav(bufType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured, UavFlag::eWriteOnly));
+
+  auto accessType = BasicType(ScalarType::eF32, type.getVectorSize());
+
+  auto srvDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eSrv, srv, builder.makeConstant(0u)));
+  auto uavDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eUav, uav, builder.makeConstant(0u)));
+
+  static const std::vector<ArithmeticTest> tests = {{
+    { ir::OpCode::eFRound, 1u, ir::RoundMode::eZero },
+    { ir::OpCode::eFAbs, 1u },
+    { ir::OpCode::eFNeg, 1u },
+    { ir::OpCode::eFAdd, 2u },
+    { ir::OpCode::eFRound, 1u, ir::RoundMode::eNearestEven },
+    { ir::OpCode::eFSub, 2u },
+    { ir::OpCode::eFRound, 1u, ir::RoundMode::eNegativeInf },
+    { ir::OpCode::eFMul, 2u },
+    { ir::OpCode::eFRound, 1u, ir::RoundMode::ePositiveInf },
+    { ir::OpCode::eFMad, 3u },
+    { ir::OpCode::eFDiv, 2u },
+    { ir::OpCode::eFRcp, 1u },
+    { ir::OpCode::eFFract, 1u },
+    { ir::OpCode::eFMin, 2u },
+    { ir::OpCode::eFMax, 2u },
+    { ir::OpCode::eFClamp, 3u },
+  }};
+
+  uint32_t srvOffset = 0u;
+
+  /* Result of last instruction */
+  auto resultDef = SsaDef();
+
+  for (const auto& e : tests) {
+    if (type.getBaseType() == ScalarType::eF64) {
+      if (e.opCode == ir::OpCode::eFRound ||
+          e.opCode == ir::OpCode::eFFract)
+        continue;
+    }
+
+    Op op(e.opCode, type);
+
+    for (uint32_t i = 0; i < e.operandCount; i++) {
+      /* Use last result as first operand */
+      SsaDef operand = i ? SsaDef() : resultDef;
+
+      if (!operand) {
+        /* Load input as F32 and convert to destination type */
+        util::small_vector<SsaDef, 4u> components;
+
+        for (uint32_t j = 0u; j < type.getVectorSize(); j++) {
+          auto& component = components.emplace_back();
+
+          auto indexDef = builder.makeConstant(srvOffset, j);
+          component = builder.add(Op::BufferLoad(accessType.getBaseType(), srvDescriptor, indexDef, accessType.byteSize()));
+
+          if (type.getBaseType() != ScalarType::eF32)
+            component = builder.add(Op::ConvertFtoF(type.getBaseType(), component));
+        }
+
+        srvOffset++;
+
+        operand = components.front();
+
+        if (type.isVector()) {
+          Op buildVectorOp(OpCode::eCompositeConstruct, type);
+
+          for (auto def : components)
+            buildVectorOp.addOperand(Operand(def));
+
+          operand = builder.add(std::move(buildVectorOp));
+        }
+      }
+
+      op.addOperand(Operand(operand));
+    }
+
+    if (e.opCode == ir::OpCode::eFRound)
+      op.addOperand(Operand(e.roundMode));
+
+    if (precise)
+      op.setFlags(OpFlag::ePrecise);
+
+    resultDef = builder.add(std::move(op));
+  }
+
+  /* Convert final result back to F32 and store */
+  for (uint32_t i = 0u; i < type.getVectorSize(); i++) {
+    auto component = resultDef;
+
+    if (type.isVector())
+      component = builder.add(Op::CompositeExtract(type.getBaseType(), resultDef, builder.makeConstant(i)));
+
+    if (type.getBaseType() != ScalarType::eF32)
+      component = builder.add(Op::ConvertFtoF(ScalarType::eF32, component));
+
+    auto indexDef = builder.makeConstant(0u, i);
+    builder.add(Op::BufferStore(uavDescriptor, indexDef, component, accessType.byteSize()));
+  }
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+
+Builder test_arithmetic_fp32() {
+  return make_test_float_arithmetic(ScalarType::eF32, false);
+}
+
+Builder test_arithmetic_fp32_precise() {
+  return make_test_float_arithmetic(ScalarType::eF32, true);
+}
+
+Builder test_arithmetic_fp32_special() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::eCompute);
+  builder.add(Op::SetCsWorkgroupSize(entryPoint, 1u, 1u, 1u));
+  builder.add(Op::Label());
+
+  auto bufType = Type(ScalarType::eF32).addArrayDimension(1u).addArrayDimension(0u);
+
+  auto srv = builder.add(Op::DclSrv(bufType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured));
+  auto uav = builder.add(Op::DclUav(bufType, entryPoint, 0u, 0u, 1u, ResourceKind::eBufferStructured, UavFlag::eWriteOnly));
+
+  static const std::vector<ir::OpCode> tests = {
+    ir::OpCode::eFLog2,
+    ir::OpCode::eFSin,
+    ir::OpCode::eFSqrt,
+    ir::OpCode::eFExp2,
+    ir::OpCode::eFRsq,
+    ir::OpCode::eFCos,
+  };
+
+  auto srvDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eSrv, srv, builder.makeConstant(0u)));
+  auto uavDescriptor = builder.add(Op::DescriptorLoad(ScalarType::eUav, uav, builder.makeConstant(0u)));
+
+  auto indexDef = builder.makeConstant(0u, 0u);
+  auto component = builder.add(Op::BufferLoad(ScalarType::eF32, srvDescriptor, indexDef, 4u));
+
+  for (auto opCode : tests)
+    component = builder.add(Op(opCode, ScalarType::eF32).addOperand(Operand(component)));
+
+  builder.add(Op::BufferStore(uavDescriptor, indexDef, component, 4u));
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_arithmetic_fp64() {
+  return make_test_float_arithmetic(ScalarType::eF64, false);
+}
+
+Builder test_arithmetic_fp16_scalar() {
+  return make_test_float_arithmetic(ScalarType::eF16, false);
+}
+
+Builder test_arithmetic_fp16_vector() {
+  return make_test_float_arithmetic(BasicType(ScalarType::eF16, 2u), false);
+}
+
+}

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -7,10 +7,13 @@ namespace dxbc_spv::test_api {
 Builder test_arithmetic_fp32();
 Builder test_arithmetic_fp32_precise();
 Builder test_arithmetic_fp32_special();
+Builder test_arithmetic_fp32_compare();
 
 Builder test_arithmetic_fp64();
+Builder test_arithmetic_fp64_compare();
 
 Builder test_arithmetic_fp16_scalar();
 Builder test_arithmetic_fp16_vector();
+Builder test_arithmetic_fp16_compare();
 
 }

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -11,9 +11,12 @@ Builder test_arithmetic_fp32_compare();
 
 Builder test_arithmetic_fp64();
 Builder test_arithmetic_fp64_compare();
+Builder test_arithmetic_fp64_packing();
 
 Builder test_arithmetic_fp16_scalar();
 Builder test_arithmetic_fp16_vector();
 Builder test_arithmetic_fp16_compare();
+Builder test_arithmetic_fp16_packing();
+Builder test_arithmetic_fp16_packing_legacy();
 
 }

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -31,4 +31,6 @@ Builder test_arithmetic_uint32_compare();
 Builder test_arithmetic_sint16_compare();
 Builder test_arithmetic_uint16_compare();
 
+Builder test_arithmetic_bool();
+
 }

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "test_api_common.h"
+
+namespace dxbc_spv::test_api {
+
+Builder test_arithmetic_fp32();
+Builder test_arithmetic_fp32_precise();
+Builder test_arithmetic_fp32_special();
+
+Builder test_arithmetic_fp64();
+
+Builder test_arithmetic_fp16_scalar();
+Builder test_arithmetic_fp16_vector();
+
+}

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -26,4 +26,9 @@ Builder test_arithmetic_sint16_vector();
 Builder test_arithmetic_uint16_scalar();
 Builder test_arithmetic_uint16_vector();
 
+Builder test_arithmetic_sint32_compare();
+Builder test_arithmetic_uint32_compare();
+Builder test_arithmetic_sint16_compare();
+Builder test_arithmetic_uint16_compare();
+
 }

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -31,6 +31,8 @@ Builder test_arithmetic_uint32_compare();
 Builder test_arithmetic_sint16_compare();
 Builder test_arithmetic_uint16_compare();
 
+Builder test_arithmetic_int_extended();
+
 Builder test_arithmetic_bool();
 
 }

--- a/tests/api/test_api_arithmetic.h
+++ b/tests/api/test_api_arithmetic.h
@@ -19,4 +19,11 @@ Builder test_arithmetic_fp16_compare();
 Builder test_arithmetic_fp16_packing();
 Builder test_arithmetic_fp16_packing_legacy();
 
+Builder test_arithmetic_sint32();
+Builder test_arithmetic_uint32();
+Builder test_arithmetic_sint16_scalar();
+Builder test_arithmetic_sint16_vector();
+Builder test_arithmetic_uint16_scalar();
+Builder test_arithmetic_uint16_vector();
+
 }

--- a/tests/api/test_api_io.cpp
+++ b/tests/api/test_api_io.cpp
@@ -225,4 +225,98 @@ Builder test_io_vs_viewport() {
   return builder;
 }
 
+Builder test_io_ps_interpolate_centroid() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::ePixel);
+
+  builder.add(Op::Label());
+
+  auto in0Def = builder.add(Op::DclInput(ScalarType::eF32, entryPoint, 0u, 0u, InterpolationMode::eNoPerspective));
+  builder.add(Op::Semantic(in0Def, 0u, "IN_SCALAR"));
+
+  auto in1Def = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u, InterpolationModes()));
+  builder.add(Op::Semantic(in1Def, 0u, "IN_VECTOR"));
+
+  auto out0Def = builder.add(Op::DclOutput(ScalarType::eF32, entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(out0Def, 0u, "SV_TARGET"));
+
+  auto out1Def = builder.add(Op::DclOutput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u));
+  builder.add(Op::Semantic(out1Def, 1u, "SV_TARGET"));
+
+  builder.add(Op::OutputStore(out0Def, SsaDef(),
+    builder.add(Op::InterpolateAtCentroid(ScalarType::eF32, in0Def))));
+
+  builder.add(Op::OutputStore(out1Def, SsaDef(),
+    builder.add(Op::InterpolateAtCentroid(BasicType(ScalarType::eF32, 3u), in1Def))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_ps_interpolate_sample() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::ePixel);
+
+  builder.add(Op::Label());
+
+  auto sampleIdDef = builder.add(Op::DclInputBuiltIn(ScalarType::eU32, entryPoint, BuiltIn::eSampleId, InterpolationMode::eFlat));
+  builder.add(Op::Semantic(sampleIdDef, 0u, "SV_SAMPLEINDEX"));
+
+  auto in0Def = builder.add(Op::DclInput(ScalarType::eF32, entryPoint, 0u, 0u, InterpolationMode::eNoPerspective));
+  builder.add(Op::Semantic(in0Def, 0u, "IN_SCALAR"));
+
+  auto in1Def = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u, InterpolationModes()));
+  builder.add(Op::Semantic(in1Def, 0u, "IN_VECTOR"));
+
+  auto out0Def = builder.add(Op::DclOutput(ScalarType::eF32, entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(out0Def, 0u, "SV_TARGET"));
+
+  auto out1Def = builder.add(Op::DclOutput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u));
+  builder.add(Op::Semantic(out1Def, 1u, "SV_TARGET"));
+
+  builder.add(Op::OutputStore(out0Def, SsaDef(),
+    builder.add(Op::InterpolateAtSample(ScalarType::eF32, in0Def,
+      builder.add(Op::InputLoad(ScalarType::eU32, sampleIdDef, SsaDef()))))));
+
+  builder.add(Op::OutputStore(out1Def, SsaDef(),
+    builder.add(Op::InterpolateAtSample(BasicType(ScalarType::eF32, 3u), in1Def,
+      builder.add(Op::InputLoad(ScalarType::eU32, sampleIdDef, SsaDef()))))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
+Builder test_io_ps_interpolate_offset() {
+  Builder builder;
+  auto entryPoint = setupTestFunction(builder, ShaderStage::ePixel);
+
+  builder.add(Op::Label());
+
+  auto offsetInputDef = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 2u), entryPoint, 2u, 0u, InterpolationModes()));
+  builder.add(Op::Semantic(offsetInputDef, 0u, "OFFSET"));
+
+  auto in0Def = builder.add(Op::DclInput(ScalarType::eF32, entryPoint, 0u, 0u, InterpolationMode::eNoPerspective));
+  builder.add(Op::Semantic(in0Def, 0u, "IN_SCALAR"));
+
+  auto in1Def = builder.add(Op::DclInput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u, InterpolationModes()));
+  builder.add(Op::Semantic(in1Def, 0u, "IN_VECTOR"));
+
+  auto out0Def = builder.add(Op::DclOutput(ScalarType::eF32, entryPoint, 0u, 0u));
+  builder.add(Op::Semantic(out0Def, 0u, "SV_TARGET"));
+
+  auto out1Def = builder.add(Op::DclOutput(BasicType(ScalarType::eF32, 3u), entryPoint, 1u, 0u));
+  builder.add(Op::Semantic(out1Def, 1u, "SV_TARGET"));
+
+  auto offsetDef = builder.add(Op::InputLoad(BasicType(ScalarType::eF32, 2u), offsetInputDef, SsaDef()));
+
+  builder.add(Op::OutputStore(out0Def, SsaDef(),
+    builder.add(Op::InterpolateAtOffset(ScalarType::eF32, in0Def, offsetDef))));
+
+  builder.add(Op::OutputStore(out1Def, SsaDef(),
+    builder.add(Op::InterpolateAtOffset(BasicType(ScalarType::eF32, 3u), in1Def, offsetDef))));
+
+  builder.add(Op::Return());
+  return builder;
+}
+
 }

--- a/tests/api/test_api_io.h
+++ b/tests/api/test_api_io.h
@@ -13,4 +13,8 @@ Builder test_io_vs_clip_cull_dist();
 Builder test_io_vs_layer();
 Builder test_io_vs_viewport();
 
+Builder test_io_ps_interpolate_centroid();
+Builder test_io_ps_interpolate_sample();
+Builder test_io_ps_interpolate_offset();
+
 }

--- a/tests/api/test_api_resources.cpp
+++ b/tests/api/test_api_resources.cpp
@@ -300,11 +300,11 @@ Builder make_test_buffer_atomic(ResourceKind kind, bool indexed) {
   auto descriptor = emit_buffer_descriptor(builder, entryPoint, kind, true, indexed, true);
   auto index = emit_buffer_load_store_address(builder, entryPoint, kind, true);
 
-  auto def = builder.add(Op::BufferAtomic(AtomicOp::eLoad, ScalarType::eU32, descriptor, index));
+  auto def = builder.add(Op::BufferAtomic(AtomicOp::eLoad, ScalarType::eU32, descriptor, index, SsaDef()));
   def = builder.add(Op::BufferAtomic(AtomicOp::eExchange, ScalarType::eU32, descriptor, index,
     builder.add(Op::IAdd(ScalarType::eU32, def, builder.makeConstant(10u)))));
   def = builder.add(Op::BufferAtomic(AtomicOp::eCompareExchange, ScalarType::eU32, descriptor, index,
-    builder.makeConstant(10u), def));
+    builder.add(Op::CompositeConstruct(BasicType(ScalarType::eU32, 2u), builder.makeConstant(10u), def))));
   def = builder.add(Op::BufferAtomic(AtomicOp::eAdd, ScalarType::eU32, descriptor, index, def));
   def = builder.add(Op::BufferAtomic(AtomicOp::eSub, ScalarType::eU32, descriptor, index, def));
   def = builder.add(Op::BufferAtomic(AtomicOp::eSMin, ScalarType::eU32, descriptor, index, def));
@@ -314,8 +314,8 @@ Builder make_test_buffer_atomic(ResourceKind kind, bool indexed) {
   def = builder.add(Op::BufferAtomic(AtomicOp::eAnd, ScalarType::eU32, descriptor, index, def));
   def = builder.add(Op::BufferAtomic(AtomicOp::eOr, ScalarType::eU32, descriptor, index, def));
   def = builder.add(Op::BufferAtomic(AtomicOp::eXor, ScalarType::eU32, descriptor, index, def));
-  def = builder.add(Op::BufferAtomic(AtomicOp::eInc, ScalarType::eU32, descriptor, index));
-  def = builder.add(Op::BufferAtomic(AtomicOp::eDec, ScalarType::eU32, descriptor, index));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eInc, ScalarType::eU32, descriptor, index, SsaDef()));
+  def = builder.add(Op::BufferAtomic(AtomicOp::eDec, ScalarType::eU32, descriptor, index, SsaDef()));
   builder.add(Op::BufferAtomic(AtomicOp::eStore, Type(), descriptor, index, def));
 
   builder.add(Op::Return());

--- a/tests/api/test_api_resources.cpp
+++ b/tests/api/test_api_resources.cpp
@@ -171,8 +171,12 @@ SsaDef emit_buffer_descriptor(Builder& builder, SsaDef entryPoint, ResourceKind 
 }
 
 SsaDef emit_buffer_load_store_address(Builder& builder, SsaDef entryPoint, ResourceKind kind, bool dynamic) {
-  auto inputDef = builder.add(Op::DclInput(BasicType(ScalarType::eU32, 2u), entryPoint, 0u, 0u, InterpolationMode::eFlat));
-  builder.add(Op::Semantic(inputDef, 0u, "BUFFER_ADDRESS"));
+  auto inputDef = SsaDef();
+
+  if (dynamic) {
+    inputDef = builder.add(Op::DclInput(BasicType(ScalarType::eU32, 2u), entryPoint, 0u, 0u, InterpolationMode::eFlat));
+    builder.add(Op::Semantic(inputDef, 0u, "BUFFER_ADDRESS"));
+  }
 
   auto index = dynamic
     ? builder.add(Op::InputLoad(ScalarType::eU32, inputDef, builder.makeConstant(0u)))


### PR DESCRIPTION
Couple changes to (mostly) integer instructions.

Turns out we also need legacy f32tof16 and f16tof32 because we can't require fp16 support, and fixing that up at runtime would be painful.