### PR TITLE
Fix an issue on MacOS

### DIFF
--- a/ir/passes/ir_pass_buffer_kind.cpp
+++ b/ir/passes/ir_pass_buffer_kind.cpp
@@ -272,7 +272,7 @@ void ConvertBufferKindPass::convertTypedBufferLoadToRaw(SsaDef use) {
   dxbc_spv_assert(vectorType.isBasicType());
 
   loadOp.setType(vectorType.getSubType(0u));
-  loadOp.setOperand(2u, static_cast<uint32_t>(sizeof(uint32_t)));
+  loadOp.setOperand(2u, uint32_t(sizeof(uint32_t)));
 
   auto loadDef = m_builder.addBefore(use, std::move(loadOp));
 
@@ -299,7 +299,7 @@ void ConvertBufferKindPass::convertTypedBufferStoreToRaw(SsaDef use) {
     value.getType().getSubType(0u), value.getDef(), m_builder.makeConstant(0u)));
 
   storeOp.setOperand(2u, valueDef);
-  storeOp.setOperand(3u, static_cast<uint32_t>(sizeof(uint32_t)));
+  storeOp.setOperand(3u, uint32_t(sizeof(uint32_t)));
 
   m_builder.rewriteOp(use, std::move(storeOp));
 }

--- a/ir/passes/ir_pass_buffer_kind.cpp
+++ b/ir/passes/ir_pass_buffer_kind.cpp
@@ -272,7 +272,7 @@ void ConvertBufferKindPass::convertTypedBufferLoadToRaw(SsaDef use) {
   dxbc_spv_assert(vectorType.isBasicType());
 
   loadOp.setType(vectorType.getSubType(0u));
-  loadOp.setOperand(2u, sizeof(uint32_t));
+  loadOp.setOperand(2u, static_cast<uint32_t>(sizeof(uint32_t)));
 
   auto loadDef = m_builder.addBefore(use, std::move(loadOp));
 
@@ -299,7 +299,7 @@ void ConvertBufferKindPass::convertTypedBufferStoreToRaw(SsaDef use) {
     value.getType().getSubType(0u), value.getDef(), m_builder.makeConstant(0u)));
 
   storeOp.setOperand(2u, valueDef);
-  storeOp.setOperand(3u, sizeof(uint32_t));
+  storeOp.setOperand(3u, static_cast<uint32_t>(sizeof(uint32_t)));
 
   m_builder.rewriteOp(use, std::move(storeOp));
 }


### PR DESCRIPTION
```
dxbc-spirv/ir/passes/../ir.h:1384:25: error: ambiguous conversion for functional-style cast from 'unsigned long' to 'Operand'
    m_operands[index] = Operand(arg);
                        ^~~~~~~~~~~
dxbc-spirv/ir/passes/ir_pass_buffer_kind.cpp:275:10: note: in instantiation of function template specialization 'dxbc_spv::ir::Op::setOperand<unsigned long>' requested here
  loadOp.setOperand(2u, sizeof(uint32_t));
         ^
dxbc-spirv/ir/passes/../ir.h:1162:12: note: candidate constructor
  explicit Operand(bool v) : Operand(v ? 1u : 0u) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1165:12: note: candidate constructor
  explicit Operand(int8_t v) : Operand(uint64_t(v)) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1166:12: note: candidate constructor
  explicit Operand(int16_t v) : Operand(uint64_t(v)) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1167:12: note: candidate constructor
  explicit Operand(int32_t v) : Operand(uint64_t(v)) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1168:12: note: candidate constructor
  explicit Operand(int64_t v) : Operand(uint64_t(v)) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1171:12: note: candidate constructor
  explicit Operand(uint8_t v) : m_data(v) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1172:12: note: candidate constructor
  explicit Operand(uint16_t v) : m_data(v) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1173:12: note: candidate constructor
  explicit Operand(uint32_t v) : m_data(v) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1174:12: note: candidate constructor
  explicit Operand(uint64_t v) : m_data(v) { }
           ^
dxbc-spirv/ir/passes/../ir.h:1180:12: note: candidate constructor
  explicit Operand(float v) {
           ^
dxbc-spirv/ir/passes/../ir.h:1188:12: note: candidate constructor
  explicit Operand(double v) {
```