### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ninja
 
 ## Tools
 
-### Disassebler
+### Disassembler
 
 This project provides a custom DXBC disassembler for debugging purposes. Its output does
 **not** match that of d3dcompiler in that it does not parse resource metadata or shader


### PR DESCRIPTION
Fix a typo in the README: Disassebler -> Disassembler