### PR TITLE
Shader Model 1-3: Instructions 5/x - Texture sampling

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -392,8 +392,7 @@ bool Converter::handleDcl(ir::Builder& builder, const Instruction& op) {
   auto dst = op.getDst();
   switch (dst.getRegisterType()) {
     case RegisterType::eSampler:
-      Logger::err("Declaring samplers is not implemented yet.");
-      return false;
+      return m_resources.handleDclSampler(builder, op);
 
     case RegisterType::eAttributeOut:
     case RegisterType::eOutput:

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -170,6 +170,8 @@ bool Converter::convertInstruction(ir::Builder& builder, const Instruction& op) 
     case OpCode::eTexM3x3:
     case OpCode::eTexLdd:
     case OpCode::eTexLdl:
+      return handleTextureSample(builder, op);
+
     case OpCode::eTexKill:
     case OpCode::eTexDepth:
     case OpCode::eLrp:
@@ -788,6 +790,142 @@ bool Converter::handleTexCoord(ir::Builder& builder, const Instruction& op) {
 
     return storeDstModifiedPredicated(builder, op, dst, src);
   }
+}
+
+
+bool Converter::handleTextureSample(ir::Builder& builder, const Instruction& op) {
+  ir::SsaDef result = ir::SsaDef();
+  auto dst = op.getDst();
+  auto opCode = op.getOpCode();
+  auto scalarType = dst.isPartialPrecision() ? ir::ScalarType::eMinF16 : ir::ScalarType::eF32;
+
+  switch (opCode) {
+    case OpCode::eTexLd: {
+      /* Regular texture sampling instruction */
+      uint32_t samplerIdx;
+      ir::SsaDef texCoord;
+      ir::SsaDef lodBias = ir::SsaDef();
+      ir::SsaDef lod = ir::SsaDef();
+
+      if (getShaderInfo().getType() == ShaderType::eVertex) {
+        lod = builder.makeConstant(0u);
+      }
+
+      if (getShaderInfo().getVersion().first <= 1u) {
+        dxbc_spv_assert(getShaderInfo().getType() == ShaderType::ePixel);
+        samplerIdx = dst.getIndex();
+        if (getShaderInfo().getVersion().second >= 4u) {
+          /* texld - ps_1_4 */
+          auto src0 = op.getSrc(0u);
+          texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
+        } else {
+          /* tex - ps_1_1 - ps_1_3 */
+          /* The destination register index decides the sampler and texture coord index. */
+          texCoord = m_ioMap.emitTexCoordLoad(builder, op, samplerIdx, ComponentBit::eAll, Swizzle::identity(), scalarType);
+        }
+      } else {
+        /* texld - sm_2_0 and up */
+        auto src0 = op.getSrc(0u);
+        auto src1 = op.getSrc(1u);
+        texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
+        samplerIdx = src1.getIndex();
+
+        switch (op.getTexLdMode()) {
+          case TexLdMode::eProject:
+            texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, false);
+            break;
+          case TexLdMode::eBias:
+            lodBias = builder.add(ir::Op::CompositeExtract(scalarType, texCoord, builder.makeConstant(3u)));
+            break;
+          default: break;
+        }
+      }
+
+      if (m_parser.getShaderInfo().getVersion().first <= 1u && m_parser.getShaderInfo().getVersion().second < 4u)
+        texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, true);
+
+      result = m_resources.emitSample(builder, samplerIdx, texCoord, lod, lodBias, ir::SsaDef(), ir::SsaDef(), scalarType);
+    } break;
+
+    case OpCode::eTexLdl: {
+      /* Sample with explicit LOD */
+      auto src0 = op.getSrc(0u);
+      auto src1 = op.getSrc(1u);
+      auto texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
+      uint32_t samplerIdx = src1.getIndex();
+      auto lod = builder.add(ir::Op::CompositeExtract(scalarType, texCoord, builder.makeConstant(3u)));
+      result = m_resources.emitSample(builder, samplerIdx, texCoord, lod, ir::SsaDef(), ir::SsaDef(), ir::SsaDef(), scalarType);
+    } break;
+
+    case OpCode::eTexLdd: {
+      /* Sample with explicit derivatives */
+      auto src0 = op.getSrc(0u);
+      auto src1 = op.getSrc(1u);
+      auto src2 = op.getSrc(2u);
+      auto src3 = op.getSrc(3u);
+      auto texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
+      uint32_t samplerIdx = src1.getIndex();
+      auto dx = loadSrcModified(builder, op, src2, ComponentBit::eAll, scalarType);
+      auto dy = loadSrcModified(builder, op, src3, ComponentBit::eAll, scalarType);
+      result = m_resources.emitSample(builder, samplerIdx, texCoord, ir::SsaDef(), ir::SsaDef(), dx, dy, scalarType);
+    } break;
+
+    case OpCode::eTexReg2Ar:
+    case OpCode::eTexReg2Gb:
+    case OpCode::eTexReg2Rgb: {
+      /* Sample with custom values used as texture coords (SM 1) */
+      Swizzle swizzle = Swizzle::identity();
+      switch (opCode) {
+        case OpCode::eTexReg2Ar:  swizzle = Swizzle(Component::eW, Component::eX, Component::eX, Component::eX); break;
+        case OpCode::eTexReg2Gb:  swizzle = Swizzle(Component::eY, Component::eZ, Component::eZ, Component::eZ); break;
+        case OpCode::eTexReg2Rgb: swizzle = Swizzle(Component::eX, Component::eY, Component::eZ, Component::eZ); break;
+        default: dxbc_spv_unreachable(); break;
+      }
+
+      auto src0 = op.getSrc(0u);
+      auto texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
+      texCoord = swizzleVector(builder, texCoord, swizzle, ComponentBit::eAll);
+      uint32_t samplerIdx = dst.getIndex();
+
+      if (m_parser.getShaderInfo().getVersion().first <= 1u && m_parser.getShaderInfo().getVersion().second < 4u)
+        texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, true);
+
+      result = m_resources.emitSample(builder, samplerIdx, texCoord, ir::SsaDef(), ir::SsaDef(), ir::SsaDef(), ir::SsaDef(), scalarType);
+    } break;
+
+    case OpCode::eTexM3x2Tex:
+    case OpCode::eTexM3x3Tex:
+    case OpCode::eTexM3x3:
+    case OpCode::eTexM3x2Depth:
+    case OpCode::eTexM3x3Spec:
+    case OpCode::eTexM3x3VSpec: {
+      // NOT YET IMPLEMENTED
+      Logger::err("OpCode ", op.getOpCode(), " is not yet implemented.");
+      return false;
+    } break;
+
+    case OpCode::eTexDp3Tex:
+    case OpCode::eTexDp3: {
+      // NOT YET IMPLEMENTED
+      Logger::err("OpCode ", op.getOpCode(), " is not yet implemented.");
+      return false;
+    } break;
+
+    case OpCode::eTexBem:
+    case OpCode::eTexBemL: {
+      // NOT YET IMPLEMENTED
+      Logger::err("OpCode ", op.getOpCode(), " is not yet implemented.");
+      return false;
+    } break;
+
+    default: {
+      Logger::err("OpCode ", op.getOpCode(), " is not supported by handleTextureSample.");
+      dxbc_spv_unreachable();
+      return false;
+    } break;
+  }
+
+  return storeDstModifiedPredicated(builder, op, dst, result);
 }
 
 

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -362,6 +362,16 @@ ir::SsaDef Converter::applyBumpMapping(ir::Builder& builder, uint32_t stageIdx, 
 }
 
 
+ir::SsaDef Converter::normalizeVector(ir::Builder& builder, ir::SsaDef def) {
+  auto type = builder.getOp(def).getType().getBaseType(0u);
+  auto scalarType = type.getBaseType();
+  uint32_t vecSize = type.getVectorSize();
+  auto lengthSquared = builder.add(emitFDot(scalarType, def, def));
+  auto lengthInv = builder.add(ir::Op::FRsq(scalarType, lengthSquared));
+  return builder.add(emitFMul(type, def, broadcastScalar(builder, lengthInv, WriteMask((1u << vecSize) - 1u))));
+}
+
+
 bool Converter::handleComment(ir::Builder& builder, const Instruction& op) {
   /* The comment is always at the start of the shader from what we've seen,
    * so no need to get extra clever here. */

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -124,6 +124,8 @@ private:
 
   ir::SsaDef applyBumpMapping(ir::Builder& builder, uint32_t stageIdx, ir::SsaDef src0, ir::SsaDef src1);
 
+  ir::SsaDef normalizeVector(ir::Builder& builder, ir::SsaDef def);
+
   bool handleComment(ir::Builder& builder, const Instruction& op);
 
   bool handleDef(ir::Builder& builder, const Instruction& op);

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -150,6 +150,8 @@ private:
 
   bool handleTexCoord(ir::Builder& builder, const Instruction& op);
 
+  bool handleTextureSample(ir::Builder& builder, const Instruction& op);
+
   ir::SsaDef loadSrc(ir::Builder& builder, const Instruction& op, const Operand& operand, WriteMask mask, Swizzle swizzle, ir::ScalarType type);
 
   ir::SsaDef applySrcModifiers(ir::Builder& builder, ir::SsaDef def, const Instruction& instruction, const Operand& operand, WriteMask mask);

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -772,6 +772,28 @@ bool IoMap::emitStore(
 }
 
 
+bool IoMap::emitDepthStore(ir::Builder &builder, const Instruction &op, ir::SsaDef value) {
+  const IoVarInfo* ioVar = findIoVar(m_variables, RegisterType::eDepthOut, 0u);
+
+  if (ioVar == nullptr) {
+    std::optional<Semantic> semantic = determineSemanticForRegister(RegisterType::eDepthOut, 0u);
+
+    if (!semantic.has_value()) {
+      m_converter.logOpError(op, "Failed to process I/O depth store.");
+      return false;
+    }
+
+    dclIoVar(builder, RegisterType::eDepthOut, 0u, semantic.value());
+    ioVar = &m_variables.back();
+  }
+
+  dxbc_spv_assert(builder.getOp(ioVar->tempDefs[0u]).getType() == builder.getOp(value).getType());
+  builder.add(ir::Op::TmpStore(ioVar->tempDefs[0u], value));
+
+  return true;
+}
+
+
 ir::SsaDef IoMap::emitDynamicLoadFunction(ir::Builder& builder) const {
   auto indexParameter = builder.add(ir::Op::DclParam(ir::ScalarType::eU32));
 

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -170,8 +170,8 @@ private:
   /** Converts input to the given scalar type. */
   ir::SsaDef convertScalar(ir::Builder& builder, ir::ScalarType dstType, ir::SsaDef value);
 
- /** Determines the appropriate semantic for a given register in shader model 1/2 */
- std::optional<Semantic> determineSemanticForRegister(RegisterType regType, uint32_t regIndex);
+  /** Determines the appropriate semantic for a given register in shader model 1/2 */
+  std::optional<Semantic> determineSemanticForRegister(RegisterType regType, uint32_t regIndex);
 
   void emitDebugName(
     ir::Builder& builder,

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -118,6 +118,14 @@ public:
 
   void emitIoVarDefaults(ir::Builder& builder);
 
+  /** Stores a scalar vector to the depth output register.
+   *
+   *  Returns \c false on error. */
+  bool emitDepthStore(
+          ir::Builder&            builder,
+    const Instruction&            op,
+          ir::SsaDef              value);
+
 private:
 
   Converter&      m_converter;

--- a/sm3/sm3_resources.cpp
+++ b/sm3/sm3_resources.cpp
@@ -396,8 +396,20 @@ ir::SsaDef ResourceMap::emitSample(
   /* Cast texCoord to F32 if necessary, sampling functions always expect Vec4<F32>. */
   auto texCoordType = builder.getOp(texCoord).getType().getBaseType(0u);
 
-  if (texCoordType.getBaseType() != ir::ScalarType::eF32)
-    texCoord = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, texCoordType.getVectorSize()), texCoord));
+  if (texCoordType != ir::BasicType(ir::ScalarType::eF32, 4u)) {
+    std::array<ir::SsaDef, 4u> texCoordComponents;
+    for (uint32_t i = 0; i < 4u; i++) {
+      if (i < texCoordType.getVectorSize()) {
+        texCoordComponents[i] = extractFromVector(builder, texCoord, i);
+        if (texCoordType.getBaseType() != ir::ScalarType::eF32) {
+          texCoordComponents[i] = builder.add(ir::Op::ConsumeAs(ir::ScalarType::eF32, texCoordComponents[i]));
+        }
+      } else {
+        texCoordComponents[i] = builder.add(ir::Op::Constant(0.0f));
+      }
+    }
+    texCoord = ir::buildVector(builder, ir::ScalarType::eF32, texCoordComponents.size(), texCoordComponents.data());
+  }
 
   /* Prepare function call with required arguments based on how we're sampling the texture. */
   auto funcCall = ir::Op::FunctionCall(ir::BasicType(ir::ScalarType::eF32, 4u), samplingFunction)

--- a/sm3/sm3_resources.cpp
+++ b/sm3/sm3_resources.cpp
@@ -356,4 +356,628 @@ void ResourceMap::emitImmediateConstant(
   }
 }
 
+
+ir::SsaDef ResourceMap::emitSample(
+            ir::Builder&   builder,
+            uint32_t       samplerIndex,
+            ir::SsaDef     texCoord,
+            ir::SsaDef     lod,
+            ir::SsaDef     lodBias,
+            ir::SsaDef     dx,
+            ir::SsaDef     dy,
+            ir::ScalarType scalarType) {
+  auto& samplerInfo = m_samplers.at(samplerIndex);
+
+  if (!samplerInfo.samplerDef) {
+    dxbc_spv_assert(m_converter.getShaderInfo().getVersion().first < 2u);
+    dclSamplerAndAllTextureTypes(builder, samplerIndex);
+  }
+
+  dxbc_spv_assert(!!dx == !!dy);
+
+  /* Load sampling function based on how we're sampling the texture. */
+
+  SamplingConfig samplingConfig = { };
+
+  if (lod)
+    samplingConfig |= SamplingConfigBit::eExplicitLod;
+
+  if (lodBias)
+    samplingConfig |= SamplingConfigBit::eLodBias;
+
+  if (dx || dy)
+    samplingConfig |= SamplingConfigBit::eExplicitDerivatives;
+
+  auto& samplingFunction = samplerInfo.samplingFunctions.at(uint8_t(samplingConfig));
+
+  if (!samplingFunction)
+    samplingFunction = emitSampleImageFunction(builder, samplerIndex, samplingConfig);
+
+  /* Cast texCoord to F32 if necessary, sampling functions always expect Vec4<F32>. */
+  auto texCoordType = builder.getOp(texCoord).getType().getBaseType(0u);
+
+  if (texCoordType.getBaseType() != ir::ScalarType::eF32)
+    texCoord = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, texCoordType.getVectorSize()), texCoord));
+
+  /* Prepare function call with required arguments based on how we're sampling the texture. */
+  auto funcCall = ir::Op::FunctionCall(ir::BasicType(ir::ScalarType::eF32, 4u), samplingFunction)
+    .addParam(texCoord);
+
+  if (lod) {
+    auto lodType = builder.getOp(lod).getType().getBaseType(0u);
+    lod = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, lodType.getVectorSize()), lod));
+    funcCall.addParam(lod);
+  }
+
+  if (lodBias) {
+    auto lodBiasType = builder.getOp(lodBias).getType().getBaseType(0u);
+    lodBias = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, lodBiasType.getVectorSize()), lodBias));
+    funcCall.addParam(lodBias);
+  }
+
+  if (dx || dy) {
+    auto dxType = builder.getOp(dx).getType().getBaseType(0u);
+    dx = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, dxType.getVectorSize()), dx));
+    funcCall.addParam(dx);
+
+    auto dyType = builder.getOp(dy).getType().getBaseType(0u);
+    dy = builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eF32, dyType.getVectorSize()), dy));
+    funcCall.addParam(dy);
+  }
+
+  auto result = builder.add(std::move(funcCall));
+
+  /* The sampling functions always return Vec4<F32>, cast if the caller expects something else. */
+  result = builder.add(ir::Op::ConsumeAs(ir::BasicType(scalarType, 4u), result));
+
+  return result;
+}
+
+
+ir::SsaDef ResourceMap::projectTexCoord(ir::Builder& builder, uint32_t samplerIndex, ir::SsaDef texCoord, bool controlWithSpecConst) {
+  auto texCoordType = builder.getOp(texCoord).getType().getBaseType(0u);
+
+  auto texCoordW = ir::extractFromVector(builder, texCoord, 3u);
+  auto projectedTexCoord = builder.add(ir::Op::FDiv(
+    texCoordType,
+    texCoord,
+    broadcastScalar(builder, texCoordW, ComponentBit::eAll)
+  ));
+
+  if (controlWithSpecConst) {
+    uint32_t specConstIdx = m_converter.m_specConstants.getSamplerSpecConstIndex(
+      m_converter.getShaderInfo().getType(), samplerIndex);
+
+    auto isProjectedSpecConst = m_converter.m_specConstants.get(
+      builder,
+      SpecConstantId::eSpecSamplerProjected,
+      builder.makeConstant(specConstIdx),
+      builder.makeConstant(1u)
+    );
+    auto isProjectedBool = builder.add(ir::Op::INe(ir::ScalarType::eBool, isProjectedSpecConst, builder.makeConstant(0u)));
+
+    return builder.add(ir::Op::Select(texCoordType, broadcastScalar(builder, isProjectedBool, WriteMask(ComponentBit::eAll)),
+      projectedTexCoord, texCoord));
+  }
+
+  return projectedTexCoord;
+}
+
+
+bool ResourceMap::handleDclSampler(ir::Builder& builder, const Instruction& op) {
+  auto dcl = op.getDcl();
+  auto dst = op.getDst();
+  uint32_t samplerIndex = dst.getIndex();
+
+  dxbc_spv_assert(dst.getRegisterType() == RegisterType::eSampler);
+
+  SpecConstTextureType textureType = specConstTextureTypeFromTextureType(dcl.getTextureType());
+
+  auto sampler = dclSampler(builder, samplerIndex);
+  auto texture = dclTexture(builder, textureType, samplerIndex);
+
+  auto& resourceInfo = m_samplers.at(samplerIndex);
+  resourceInfo.regIndex = samplerIndex;
+  resourceInfo.samplerDef = sampler;
+  resourceInfo.textureDefs[uint32_t(textureType)] = texture;
+  resourceInfo.textureType = std::optional(textureType);
+  return true;
+}
+
+
+bool ResourceMap::dclSamplerAndAllTextureTypes(ir::Builder& builder, uint32_t samplerIndex) {
+  auto sampler = dclSampler(builder, samplerIndex);
+
+  std::array<ir::SsaDef, uint32_t(SpecConstTextureType::eTexture3D) + 1u> textures;
+
+  for (uint32_t i = 0; i < textures.size(); i++) {
+    SpecConstTextureType textureType = SpecConstTextureType(i);
+    textures[i] = dclTexture(builder, textureType, samplerIndex);
+  }
+
+  auto& resourceInfo = m_samplers.at(samplerIndex);
+  resourceInfo.regIndex = samplerIndex;
+  resourceInfo.samplerDef = sampler;
+  resourceInfo.textureDefs = textures;
+  return true;
+}
+
+
+ir::SsaDef ResourceMap::dclSampler(ir::Builder& builder, uint32_t samplerIndex) {
+  auto samplerDef = builder.add(ir::Op::DclSampler(m_converter.getEntryPoint(), SamplerBindingsRegSpace, samplerIndex, 1u));
+
+  if (m_converter.m_options.includeDebugNames) {
+    const ConstantInfo* ctabEntry = nullptr;
+
+    for (const auto& entry : m_converter.m_ctab.entries()) {
+      if (entry.registerSet != ConstantType::eSampler)
+        continue;
+
+      if (entry.index <= samplerIndex && entry.index + entry.count > samplerIndex) {
+        ctabEntry = &entry;
+        break;
+      }
+    }
+
+    std::stringstream nameStream;
+    nameStream << "s_";
+    nameStream << samplerIndex;
+
+    if (ctabEntry) {
+      nameStream << "_";
+      nameStream << ctabEntry->name;
+    }
+
+    std::string name = nameStream.str();
+    builder.add(ir::Op::DebugName(samplerDef, name.c_str()));
+  }
+
+  return samplerDef;
+}
+
+
+ir::SsaDef ResourceMap::dclTexture(ir::Builder& builder, SpecConstTextureType textureType, uint32_t samplerIndex) {
+  auto textureDef = builder.add(ir::Op::DclSrv(ir::ScalarType::eF32, m_converter.getEntryPoint(), TextureBindingsRegSpace,
+    samplerIndex, 1u, resourceKindFromTextureType(textureTypeFromSpecConstTextureType(textureType))));
+
+  if (m_converter.m_options.includeDebugNames) {
+    const ConstantInfo* ctabEntry = nullptr;
+
+    for (const auto& entry : m_converter.m_ctab.entries()) {
+      if (entry.registerSet != ConstantType::eSampler)
+        continue;
+
+      if (entry.index <= samplerIndex && entry.index + entry.count > samplerIndex) {
+        ctabEntry = &entry;
+        break;
+      }
+    }
+
+    std::stringstream nameStream;
+    nameStream << "s_";
+    nameStream << samplerIndex;
+
+    if (ctabEntry) {
+      nameStream << "_";
+      nameStream << ctabEntry->name;
+    }
+
+    nameStream << "_";
+    nameStream << textureTypeFromSpecConstTextureType(textureType);
+
+    std::string name = nameStream.str();
+    builder.add(ir::Op::DebugName(textureDef, name.c_str()));
+  }
+
+  return textureDef;
+}
+
+
+ir::SsaDef ResourceMap::emitSampleImageFunction(
+  ir::Builder &builder,
+  uint32_t samplerIndex,
+  SamplingConfig config
+) {
+  uint32_t specConstIdx = m_converter.m_specConstants.getSamplerSpecConstIndex(
+    m_converter.getShaderInfo().getType(), samplerIndex);
+
+  auto vec4FType = ir::BasicType(ir::ScalarType::eF32, 4u);
+  auto functionOp = ir::Op::Function(vec4FType);
+
+  /* TexCoord */
+  auto texCoordParam = builder.add(ir::Op::DclParam(vec4FType));
+  functionOp.addOperand(texCoordParam);
+
+  if (m_converter.getOptions().includeDebugNames)
+    builder.add(ir::Op::DebugName(texCoordParam, "texCoord"));
+
+  ir::SsaDef lodParam = { };
+  ir::SsaDef lodBiasParam = { };
+  ir::SsaDef dxParam = { };
+  ir::SsaDef dyParam = { };
+
+  if (config & SamplingConfigBit::eExplicitLod) {
+    /* Lod */
+    lodParam = builder.add(ir::Op::DclParam(ir::ScalarType::eF32));
+    functionOp.addOperand(lodParam);
+
+    if (m_converter.getOptions().includeDebugNames) {
+      builder.add(ir::Op::DebugName(lodParam, "lod"));
+    }
+  }
+
+  if (config & SamplingConfigBit::eLodBias) {
+    /* LodBias */
+    lodBiasParam = builder.add(ir::Op::DclParam(ir::ScalarType::eF32));
+    functionOp.addOperand(lodBiasParam);
+
+    if (m_converter.getOptions().includeDebugNames) {
+      builder.add(ir::Op::DebugName(lodBiasParam, "lodBias"));
+    }
+  }
+
+  if (config & SamplingConfigBit::eExplicitDerivatives) {
+    dxParam = builder.add(ir::Op::DclParam(ir::BasicType(ir::ScalarType::eF32, 4u))); /* Dx */
+    dyParam = builder.add(ir::Op::DclParam(ir::BasicType(ir::ScalarType::eF32, 4u))); /* Dy */
+
+    functionOp.addOperand(dxParam);
+    functionOp.addOperand(dyParam);
+
+    if (m_converter.getOptions().includeDebugNames) {
+      builder.add(ir::Op::DebugName(dxParam, "dxParam"));
+      builder.add(ir::Op::DebugName(dyParam, "dyParam"));
+    }
+  }
+
+  auto function = builder.addBefore(builder.getCode().first->getDef(), std::move(functionOp));
+  auto cursor = builder.setCursor(function);
+
+  auto texCoord = builder.add(ir::Op::ParamLoad(vec4FType, function, texCoordParam));
+  auto lod = lodParam ? builder.add(ir::Op::ParamLoad(ir::ScalarType::eF32, function, lodParam)) : ir::SsaDef();
+  auto lodBias = lodBiasParam ? builder.add(ir::Op::ParamLoad(ir::ScalarType::eF32, function, lodBiasParam)) : ir::SsaDef();
+  auto dx = dxParam ? builder.add(ir::Op::ParamLoad(ir::BasicType(ir::ScalarType::eF32, 4u), function, dxParam)) : ir::SsaDef();
+  auto dy = dyParam ? builder.add(ir::Op::ParamLoad(ir::BasicType(ir::ScalarType::eF32, 4u), function, dyParam)) : ir::SsaDef();
+
+  const auto& samplerInfo = m_samplers.at(samplerIndex);
+  dxbc_spv_assert(samplerInfo.regIndex == samplerIndex);
+  auto sampler = builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSampler, samplerInfo.samplerDef, builder.makeConstant(0u)));
+
+  if (m_converter.getShaderInfo().getVersion().first >= 2) {
+    /* Shader model 2+ requires declaring samplers/textures with a DCL instruction first. */
+    dxbc_spv_assert(samplerInfo.textureType.has_value());
+
+    auto specConstTextureType = samplerInfo.textureType.value();
+
+    auto descriptor = builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv,
+      samplerInfo.textureDefs[uint32_t(specConstTextureType)],
+      builder.makeConstant(0u)));
+
+    builder.add(ir::Op::Return(ir::BasicType(ir::ScalarType::eF32, 4u), emitSampleColorOrDref(builder, texCoord, specConstTextureType, samplerIndex, descriptor, sampler, lod, lodBias, dx, dy)));
+  } else {
+    /* Shader model 1 does not require declaring samplers/textures with a DCL instruction.
+     * We emit a switch() block with one case for each texture type. Decide based on a spec constant. */
+    auto resultTmp = builder.add(ir::Op::DclTmp(ir::BasicType(ir::ScalarType::eF32, 4u), m_converter.getEntryPoint()));
+    builder.add(ir::Op::TmpStore(resultTmp, ir::broadcastScalar(builder, builder.makeConstant(0.0f), ComponentBit::eAll)));
+
+    /* Load spec constant. */
+    auto samplerTypeSpecConst = m_converter.m_specConstants.get(
+      builder,
+      SpecConstantId::eSpecSamplerType,
+      builder.makeConstant(2u * specConstIdx),
+      builder.makeConstant(2u)
+    );
+
+    auto textureTypeSwitch = builder.add(ir::Op::ScopedSwitch(ir::SsaDef(), samplerTypeSpecConst));
+
+    /* Emit a switch case for each texture type. */
+    for (uint32_t i = 0; i <= uint32_t(SpecConstTextureType::eTexture3D); i++) {
+      builder.add(ir::Op::ScopedSwitchCase(textureTypeSwitch, i));
+
+      auto descriptor = builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv,
+        samplerInfo.textureDefs[i],
+        builder.makeConstant(0u)));
+
+      auto typeResult = emitSampleColorOrDref(builder, texCoord, SpecConstTextureType(i), samplerIndex, descriptor, sampler, lod, lodBias, dx, dy);
+
+      builder.add(ir::Op::TmpStore(resultTmp, typeResult));
+      builder.add(ir::Op::ScopedSwitchBreak(textureTypeSwitch));
+    }
+
+    auto textureTypeSwitchEnd = builder.add(ir::Op::ScopedEndSwitch(textureTypeSwitch));
+    builder.rewriteOp(textureTypeSwitch, ir::Op(builder.getOp(textureTypeSwitch)).setOperand(0u, textureTypeSwitchEnd));
+
+    /* Return whatever value we loaded in the texture type switch. */
+    auto returnVal = builder.add(ir::Op::TmpLoad(ir::BasicType(ir::ScalarType::eF32, 4u), resultTmp));
+    builder.add(ir::Op::Return(ir::BasicType(ir::ScalarType::eF32, 4u), returnVal));
+  }
+
+  builder.add(ir::Op::FunctionEnd());
+
+  if (m_converter.m_options.includeDebugNames) {
+    const ConstantInfo* ctabEntry = nullptr;
+
+    for (const auto& entry : m_converter.m_ctab.entries()) {
+      if (entry.registerSet != ConstantType::eSampler)
+        continue;
+
+      if (entry.index <= samplerIndex && entry.index + entry.count > samplerIndex) {
+        ctabEntry = &entry;
+        break;
+      }
+    }
+
+    std::stringstream nameStream;
+    nameStream << "sampleTexture_";
+    nameStream << samplerIndex;
+
+    if (ctabEntry) {
+      nameStream << "_";
+      nameStream << ctabEntry->name;
+    }
+
+    if (config & SamplingConfigBit::eExplicitLod)
+      nameStream << "_explicit";
+
+    if (config & SamplingConfigBit::eLodBias)
+      nameStream << "_bias";
+
+    if (config & SamplingConfigBit::eExplicitDerivatives)
+      nameStream << "_grad";
+
+
+    std::string name = nameStream.str();
+    builder.add(ir::Op::DebugName(function, name.c_str()));
+  }
+
+  builder.setCursor(cursor);
+  return function;
+}
+
+
+ir::SsaDef ResourceMap::emitSampleColorOrDref(
+  ir::Builder& builder,
+  ir::SsaDef texCoord,
+  SpecConstTextureType textureType,
+  uint32_t samplerIndex,
+  ir::SsaDef descriptor,
+  ir::SsaDef sampler,
+  ir::SsaDef lod,
+  ir::SsaDef lodBias,
+  ir::SsaDef dx,
+  ir::SsaDef dy
+) {
+  uint32_t specConstIdx = m_converter.m_specConstants.getSamplerSpecConstIndex(
+    m_converter.getShaderInfo().getType(), samplerIndex);
+
+  if (textureType != SpecConstTextureType::eTexture3D) {
+    auto resultTmp = builder.add(ir::Op::DclTmp(ir::BasicType(ir::ScalarType::eF32, 4u), m_converter.getEntryPoint()));
+
+    auto isDepth = m_converter.m_specConstants.get(
+      builder,
+      SpecConstantId::eSpecSamplerDepthMode,
+      builder.makeConstant(specConstIdx),
+      builder.makeConstant(1u)
+    );
+    auto isDepthCondition = builder.add(ir::Op::INe(ir::ScalarType::eBool, isDepth, builder.makeConstant(0u)));
+
+    /* if (SpecSamplerDepthMode & (1u << samplerIndex)) */
+    auto isDepthIf = builder.add(ir::Op::ScopedIf(ir::SsaDef(), isDepthCondition));
+    auto depthResult = emitSampleDref(builder, texCoord, textureType, descriptor, sampler, lod, lodBias, dx, dy);
+    builder.add(ir::Op::TmpStore(resultTmp, depthResult));
+
+    /* else */
+    builder.add(ir::Op::ScopedElse(isDepthIf));
+    auto colorResult = emitSampleColorImageType(builder, texCoord, textureType, samplerIndex, descriptor, sampler, lod, lodBias, dx, dy);
+    builder.add(ir::Op::TmpStore(resultTmp, colorResult));
+
+    /* endif */
+    auto isDepthEnd = builder.add(ir::Op::ScopedEndIf(isDepthIf));
+    builder.rewriteOp(isDepthIf, ir::Op(builder.getOp(isDepthIf)).setOperand(0u, isDepthEnd));
+
+    return builder.add(ir::Op::TmpLoad(ir::BasicType(ir::ScalarType::eF32, 4u), resultTmp));
+  } else {
+    return emitSampleColorImageType(builder, texCoord, textureType, samplerIndex, descriptor, sampler, lod, lodBias, dx, dy);
+  }
+}
+
+
+ir::SsaDef ResourceMap::emitSampleColorImageType(
+  ir::Builder& builder,
+  ir::SsaDef texCoord,
+  SpecConstTextureType textureType,
+  uint32_t samplerIndex,
+  ir::SsaDef descriptor,
+  ir::SsaDef sampler,
+  ir::SsaDef lod,
+  ir::SsaDef lodBias,
+  ir::SsaDef dx,
+  ir::SsaDef dy
+) {
+  uint32_t specConstIdx = m_converter.m_specConstants.getSamplerSpecConstIndex(
+    m_converter.getShaderInfo().getType(), samplerIndex);
+
+  uint32_t texCoordComponentCount = textureType == SpecConstTextureType::eTexture2D ? 2u : 3u;
+  std::array<ir::SsaDef, 4u> texCoordComponents;
+
+  for (uint32_t i = 0u; i < texCoordComponentCount; i++) {
+    texCoordComponents[i] = ir::extractFromVector(builder, texCoord, i);
+  }
+
+  auto sizedTexCoord = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, texCoordComponents.data());
+
+  auto sizedDx = ir::SsaDef();
+  auto sizedDy = ir::SsaDef();
+
+  if (dx && dy) {
+    /* Load derivatives for textureGrad sampling function. */
+    std::array<ir::SsaDef, 4u> dxComponents;
+    std::array<ir::SsaDef, 4u> dyComponents;
+
+    for (uint32_t i = 0u; i < texCoordComponentCount; i++) {
+      dxComponents[i] = ir::extractFromVector(builder, dx, i);
+      dyComponents[i] = ir::extractFromVector(builder, dy, i);
+    }
+
+    sizedDx = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, dxComponents.data());
+    sizedDy = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, dyComponents.data());
+  }
+
+  auto color = builder.add(ir::Op::ImageSample(
+    ir::BasicType(ir::ScalarType::eF32, 4u),
+    descriptor, sampler, ir::SsaDef(), sizedTexCoord,
+    ir::SsaDef(), lod, lodBias, ir::SsaDef(),
+    sizedDx, sizedDy, ir::SsaDef() ));
+
+  /* Fetch4
+   * D3D9 does support gather on 3D but we cannot :< */
+  if (m_converter.getShaderInfo().getType() == ShaderType::ePixel && textureType != SpecConstTextureType::eTexture3D) {
+
+    /* Load the spec constant that tells us if fetch4 (gather) is enabled for the sampler. */
+    auto fetch4EnabledSpecConst = m_converter.m_specConstants.get(
+      builder,
+      SpecConstantId::eSpecSamplerFetch4,
+      builder.makeConstant(specConstIdx),
+      builder.makeConstant(1u)
+    );
+    auto fetch4Enabled = builder.add(ir::Op::INe(ir::ScalarType::eBool, fetch4EnabledSpecConst, builder.makeConstant(0u)));
+
+    /* Account for half texel offset */
+    if (textureType == SpecConstTextureType::eTexture2D) {
+      /* Doesn't really work for cubes...
+       * Nothing probably relies on that though.
+       * If we come back to this ever, make sure to handle cube/3d differences.
+       *   texcoord += (1.0f - 1.0f / 256.0f) / float(2 * textureSize(sampler, 0))
+       * = texcoord += (256.0f / 512.0f) / textureSize(sampler, 0) */
+
+      auto coordDims = ir::resourceDimensions(resourceKindFromTextureType(textureTypeFromSpecConstTextureType(textureType)));
+      auto sizeType = ir::Type()
+        .addStructMember(ir::ScalarType::eU32, coordDims)    /* size   */
+        .addStructMember(ir::ScalarType::eU32);           /* layers */
+
+      /* HACK: Bias fetch4 half-texel offset to avoid a "grid" effect.
+       * Technically we should only do that for non-powers of two
+       * as only then does the imprecision need to be biased
+       * towards infinity -- but that's not really worth doing... */
+      float numerator = 256.0f / 512.0f;
+
+      auto textureSizeStruct = builder.add(ir::Op::ImageQuerySize(sizeType, descriptor, builder.makeConstant(0u)));
+      auto textureSizeI = ir::extractFromVector(builder, textureSizeStruct, 0u);
+      auto textureSizeType = ir::BasicType(ir::ScalarType::eF32, coordDims);
+      auto textureSizeF = builder.add(ir::Op::ConvertItoF(textureSizeType, textureSizeI));
+
+      auto numeratorVec = broadcastScalar(builder, builder.makeConstant(numerator), util::makeWriteMaskForComponents(coordDims));
+      auto invTextureSize = builder.add(ir::Op::FDiv(textureSizeType, numeratorVec, textureSizeF));
+
+      /* texcoord += invTextureSize */
+      sizedTexCoord = builder.add(ir::Op::FAdd(textureSizeType, sizedTexCoord, invTextureSize));
+    }
+
+    auto fetch4Val = builder.add(ir::Op::ImageGather(
+      ir::BasicType(ir::ScalarType::eF32, 4u),
+      descriptor, sampler, ir::SsaDef(), sizedTexCoord,
+      ir::SsaDef(), ir::SsaDef(), 0u ));
+
+    /* Shuffle the vector to match the funny D3D9 order: B R G A */
+    fetch4Val = swizzleVector(builder, fetch4Val, Swizzle(Component::eZ, Component::eX, Component::eY, Component::eW), WriteMask(ComponentBit::eAll));
+
+    /* Use Fetch4 value if spec constant bit is set and regular sampled color if not. */
+    color = builder.add(ir::Op::Select(ir::BasicType(ir::ScalarType::eF32, 4u),
+    broadcastScalar(builder, fetch4Enabled, WriteMask(ComponentBit::eAll)),
+    fetch4Val, color));
+  }
+
+  /* Load the spec constant that tells us if the texture is unbound. */
+
+  auto isNullSpecConst = m_converter.m_specConstants.get(
+    builder,
+    SpecConstantId::eSpecSamplerNull,
+    builder.makeConstant(specConstIdx),
+    builder.makeConstant(1u)
+  );
+  auto isNull = builder.add(ir::Op::INe(ir::ScalarType::eBool, isNullSpecConst, builder.makeConstant(0u)));
+
+  return builder.add(ir::Op::Select(
+    ir::BasicType(ir::ScalarType::eF32, 4u),
+    broadcastScalar(builder, isNull, WriteMask(ComponentBit::eAll)),
+    builder.makeConstant(0.0f, 0.0f, 0.0f, 1.0f),
+    color));
+}
+
+
+ir::SsaDef ResourceMap::emitSampleDref(
+  ir::Builder &builder,
+  ir::SsaDef texCoord,
+  SpecConstTextureType textureType,
+  ir::SsaDef descriptor,
+  ir::SsaDef sampler,
+  ir::SsaDef lod,
+  ir::SsaDef lodBias,
+  ir::SsaDef dx,
+  ir::SsaDef dy
+) {
+  /* We don't check for NULL here because if there's no texture bound, we always end up in the color path. */
+
+  uint32_t texCoordComponentCount = textureType == SpecConstTextureType::eTexture2D ? 2u : 3u;
+  auto reference = ir::extractFromVector(builder, texCoord, texCoordComponentCount);
+
+  /* [D3D8] Scale Dref from [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled */
+  auto drefScaleShift = m_converter.m_specConstants.get(
+    builder,
+    SpecConstantId::eSpecDrefScaling
+  );
+
+  auto drefScale = builder.add(ir::Op::IShl(ir::ScalarType::eU32, builder.makeConstant(1u), drefScaleShift));
+  drefScale      = builder.add(ir::Op::ConvertItoF(ir::ScalarType::eF32, drefScale));
+  drefScale      = builder.add(ir::Op::FSub(ir::ScalarType::eF32, drefScale, builder.makeConstant(1.0f)));
+  drefScale      = builder.add(ir::Op::FDiv(ir::ScalarType::eF32, builder.makeConstant(1.0f), drefScale));
+
+  reference      = builder.add(ir::Op::Select(ir::ScalarType::eF32,
+    builder.add(ir::Op::INe(ir::ScalarType::eBool, drefScaleShift, builder.makeConstant(0u))),
+    builder.add(ir::Op::FMul(ir::ScalarType::eF32, reference, drefScale)),
+    reference
+  ));
+
+  /* Clamp Dref to [0..1] for D32F emulating UNORM textures */
+  auto clampDref = m_converter.m_specConstants.get(
+    builder,
+    SpecConstantId::eSpecSamplerDrefClamp
+  );
+  clampDref = builder.add(ir::Op::INe(ir::ScalarType::eBool, clampDref, builder.makeConstant(0u)));
+
+  auto clampedDref = builder.add(ir::Op::FClamp(ir::ScalarType::eF32, reference, builder.makeConstant(0.0f), builder.makeConstant(1.0f)));
+  reference = builder.add(ir::Op::Select(ir::ScalarType::eF32, clampDref, clampedDref, reference));
+
+  std::array<ir::SsaDef, 4u> texCoordComponents;
+  for (uint32_t i = 0u; i < texCoordComponentCount; i++) {
+    texCoordComponents[i] = ir::extractFromVector(builder, texCoord, i);
+  }
+
+  auto sizedTexCoord = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, texCoordComponents.data());
+
+  auto sizedDx = ir::SsaDef();
+  auto sizedDy = ir::SsaDef();
+
+  if (dx && dy) {
+    /* Load derivatives for textureGrad sampling function. */
+    std::array<ir::SsaDef, 4u> dxComponents;
+    std::array<ir::SsaDef, 4u> dyComponents;
+
+    for (uint32_t i = 0u; i < texCoordComponentCount; i++) {
+      dxComponents[i] = ir::extractFromVector(builder, dx, i);
+      dyComponents[i] = ir::extractFromVector(builder, dy, i);
+    }
+
+    sizedDx = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, dxComponents.data());
+    sizedDy = buildVector(builder, ir::ScalarType::eF32, texCoordComponentCount, dyComponents.data());
+  }
+
+  auto drefResult = builder.add(ir::Op::ImageSample(
+    ir::ScalarType::eF32, descriptor, sampler,
+    ir::SsaDef(), sizedTexCoord, ir::SsaDef(),
+    lod, lodBias, ir::SsaDef(),
+    sizedDx, sizedDy, reference ));
+
+  return broadcastScalar(builder, drefResult, WriteMask(ComponentBit::eAll));
+}
+
 }

--- a/sm3/sm3_resources.h
+++ b/sm3/sm3_resources.h
@@ -12,6 +12,45 @@ namespace dxbc_spv::sm3 {
 
 class Converter;
 
+enum class SpecConstTextureType : uint32_t {
+  eTexture2D   = 0u,
+  eTextureCube = 1u,
+  eTexture3D   = 2u,
+};
+
+enum class SamplingConfigBit : uint8_t {
+  eExplicitLod         = 1u << 0u,
+  eLodBias             = 1u << 1u,
+  eExplicitDerivatives = 1u << 2u,
+
+  eFlagEnum            = 0u,
+};
+
+using SamplingConfig = util::Flags<SamplingConfigBit>;
+
+struct SamplerRegister {
+  /** Register index */
+  uint32_t regIndex = 0u;
+
+  /** Declaration of the texture
+   * One for each texture type on SM1 and only one on SM2+ */
+  std::array<ir::SsaDef, 3u> textureDefs = { };
+
+  /** The type of the texture. This is only set on SM2+ as there are no dcl_samplerType instructions
+   * on SM1. This texture type represents the index of the one valid `textureDef` on SM2. */
+  std::optional<SpecConstTextureType> textureType = std::nullopt;
+
+  /** Declaration of the sampler */
+  ir::SsaDef samplerDef = { };
+
+  /** Sampling functions. Will be populated lazily.
+   * A SamplingFunctionConfigBit bitmask makes up the index into this array.
+   * Each function takes in an F32 vec4 for the texCoords and some
+   * will take additional arguments for LODs and/or derivatives depending
+   * on the flags. */
+  std::array<ir::SsaDef, 8u> samplingFunctions = { };
+};
+
 struct ConstantRange {
   /** Declaration of a buffer that has the debug CTAB name. (Only used for debugging.). */
   ir::SsaDef namedBufferDef = { };
@@ -60,6 +99,25 @@ public:
 
   void emitNamedConstantRanges(ir::Builder& builder, const ConstantTable& ctab);
 
+  /** Handles Dcl instructions on SM 2+ with Sampler as the register type. */
+  bool handleDclSampler(ir::Builder& builder, const Instruction& op);
+
+  bool dclSamplerAndAllTextureTypes(ir::Builder& builder, uint32_t samplerIndex);
+
+  ir::SsaDef projectTexCoord(ir::Builder& builder, uint32_t samplerIndex, ir::SsaDef texCoord, bool controlWithSpecConst);
+
+  /** Loads a resource or sampler descriptor and retrieves basic
+   *  properties required to perform any operations on typed resources. */
+  ir::SsaDef emitSample(
+          ir::Builder&   builder,
+          uint32_t       samplerIndex,
+          ir::SsaDef     texCoord,
+          ir::SsaDef     lod,
+          ir::SsaDef     lodBias,
+          ir::SsaDef     dx,
+          ir::SsaDef     dy,
+          ir::ScalarType scalarType);
+
   /** Loads data from a constant buffer using one or more BufferLoad
    *  instruction. If possible this will emit a vectorized load. */
   ir::SsaDef emitConstantLoad(
@@ -79,8 +137,93 @@ private:
 
   Converter& m_converter;
 
+  std::array<SamplerRegister, 32> m_samplers;
+
   std::array<Constants, uint32_t(ConstantType::eSampler)> m_constants;
 
+  ir::SsaDef dclSampler(ir::Builder& builder, uint32_t samplerIndex);
+
+  ir::SsaDef dclTexture(ir::Builder& builder, SpecConstTextureType textureType, uint32_t samplerIndex);
+
+  ir::SsaDef emitSampleImageFunction(
+    ir::Builder& builder,
+    uint32_t samplerIndex,
+    SamplingConfig config
+  );
+
+  ir::SsaDef emitSampleColorOrDref(
+    ir::Builder& builder,
+    ir::SsaDef texCoord,
+    SpecConstTextureType textureType,
+    uint32_t samplerIndex,
+    ir::SsaDef descriptor,
+    ir::SsaDef sampler,
+    ir::SsaDef lod,
+    ir::SsaDef lodBias,
+    ir::SsaDef dx,
+    ir::SsaDef dy
+  );
+
+  ir::SsaDef emitSampleColorImageType(
+    ir::Builder& builder,
+    ir::SsaDef texCoord,
+    SpecConstTextureType textureType,
+    uint32_t samplerIndex,
+    ir::SsaDef descriptor,
+    ir::SsaDef sampler,
+    ir::SsaDef lod,
+    ir::SsaDef lodBias,
+    ir::SsaDef dx,
+    ir::SsaDef dy
+  );
+
+  ir::SsaDef emitSampleDref(
+    ir::Builder& builder,
+    ir::SsaDef texCoord,
+    SpecConstTextureType textureType,
+    ir::SsaDef descriptor,
+    ir::SsaDef sampler,
+    ir::SsaDef lod,
+    ir::SsaDef lodBias,
+    ir::SsaDef dx,
+    ir::SsaDef dy
+  );
+
 };
+
+
+inline ir::ResourceKind resourceKindFromTextureType(TextureType textureType) {
+  switch (textureType) {
+    case TextureType::eTexture2D:
+      return ir::ResourceKind::eImage2D;
+    case TextureType::eTextureCube:
+      return ir::ResourceKind::eImageCube;
+    case TextureType::eTexture3D:
+      return ir::ResourceKind::eImage3D;
+  }
+  return ir::ResourceKind::eBufferRaw;
+}
+
+inline SpecConstTextureType specConstTextureTypeFromTextureType(TextureType textureType) {
+  return SpecConstTextureType(uint32_t(textureType) - uint32_t(TextureType::eTexture2D));
+}
+
+inline TextureType textureTypeFromSpecConstTextureType(SpecConstTextureType specConstTextureType) {
+  return TextureType(uint32_t(specConstTextureType) + uint32_t(TextureType::eTexture2D));
+}
+
+inline SpecConstTextureType specConstTextureTypeFromResourceKind(ir::ResourceKind resourceKind) {
+  switch (resourceKind) {
+    case ir::ResourceKind::eImage2D:
+      return SpecConstTextureType::eTexture2D;
+    case ir::ResourceKind::eImage3D:
+      return SpecConstTextureType::eTexture3D;
+    case ir::ResourceKind::eImageCube:
+      return SpecConstTextureType::eTextureCube;
+    default:
+      dxbc_spv_unreachable();
+      return SpecConstTextureType::eTexture2D;
+  }
+}
 
 }

--- a/sm3/sm3_types.h
+++ b/sm3/sm3_types.h
@@ -13,6 +13,11 @@ using util::ComponentBit;
 using util::WriteMask;
 using util::Swizzle;
 
+/* Texture sampling binding constants */
+
+constexpr uint32_t TextureBindingsRegSpace = 0u;
+constexpr uint32_t SamplerBindingsRegSpace = 1u;
+
 /* CBV Register indices */
 
 constexpr uint32_t FastSpecConstCbvRegIdx = 0u;


### PR DESCRIPTION
This is where it gets interesting. Pretty much a port of what we currently do in the old shader compiler, except that I put it in functions to make it more readable. This helps readability a lot with how much spec const magic we do for every texture sampling instruction.