### PR TITLE
Introduce control to relax memory ordering semantics for atomics on Intel HW

### DIFF
--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -2420,7 +2420,15 @@ void SpirvBuilder::emitAtomic(const ir::Op& op, const ir::Type& type, uint32_t i
   /* Set up memory semantics */
   auto semantics = spv::MemorySemanticsMaskNone;
 
-  if (scope != spv::ScopeInvocation) {
+  /* Intel-specific path
+
+     DX specification does not mention any additional synchronization requirements for atomics.
+     Therefore we could relax memory semantics on atomics in DX shaders on Intel HW. */
+  if (m_options.intelRelaxAtomicMemoryOrderingSemantics) {
+    if (scope != spv::ScopeInvocation) {
+      semantics = spv::MemorySemanticsMask(memoryTypes | semantics);
+    }
+  } else if (scope != spv::ScopeInvocation) {
     semantics = spv::MemorySemanticsAcquireReleaseMask |
                 spv::MemorySemanticsMakeVisibleMask |
                 spv::MemorySemanticsMakeAvailableMask;

--- a/spirv/spirv_builder.h
+++ b/spirv/spirv_builder.h
@@ -55,6 +55,8 @@ public:
     int32_t maxCbvCount = -1;
     /** Maximum tessellation factor supported by the device. */
     float maxTessFactor = 64.0f;
+    /** Relax atomics semantics on Intel HW. */
+    bool intelRelaxAtomicMemoryOrderingSemantics = false;
   };
 
   explicit SpirvBuilder(const ir::Builder& builder, ResourceMapping& mapping, const Options& options);


### PR DESCRIPTION
DX specification does not mention any additional synchronization requirements for atomics, e.g.:
https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/atomic-iadd--sm5---asm-
Therefore the semantics could be relaxed for certain HW to not introduce additional synchronization.

To be followed with dxvk change to set the flag on Intel HW.