### PR TITLE
Shader Model 1: Rewrite how texture registers are handled.

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -246,6 +246,16 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
 
 
 bool Converter::finalize(ir::Builder& builder, ShaderType shaderType) {
+  if (getShaderInfo().getVersion().first == 1u) {
+    /* Shader model 1 doesn't have special color output registers.
+     * Instead, it simply outputs what was in Temp register 0 (r0) at the end. */
+    auto value = m_regFile.emitTempLoad(builder, 0u,
+      Swizzle::identity(), WriteMask(ComponentBit::eAll), ir::ScalarType::eF32);
+
+    if (!m_ioMap.emitColorStore(builder, value))
+      return false;
+  }
+
   m_ioMap.finalize(builder);
 
   return true;

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -820,6 +820,9 @@ bool Converter::handleTextureSample(ir::Builder& builder, const Instruction& op)
           /* tex - ps_1_1 - ps_1_3 */
           /* The destination register index decides the sampler and texture coord index. */
           texCoord = m_ioMap.emitTexCoordLoad(builder, op, samplerIdx, ComponentBit::eAll, Swizzle::identity(), scalarType);
+
+          /* D3DTTFF_PROJECTED only impacts the ps_1_1 - ps_1_3 tex instruction. */
+          texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, true);
         }
       } else {
         /* texld - sm_2_0 and up */
@@ -838,9 +841,6 @@ bool Converter::handleTextureSample(ir::Builder& builder, const Instruction& op)
           default: break;
         }
       }
-
-      if (m_parser.getShaderInfo().getVersion().first <= 1u && m_parser.getShaderInfo().getVersion().second < 4u)
-        texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, true);
 
       result = m_resources.emitSample(builder, samplerIdx, texCoord, lod, lodBias, ir::SsaDef(), ir::SsaDef(), scalarType);
     } break;
@@ -884,9 +884,6 @@ bool Converter::handleTextureSample(ir::Builder& builder, const Instruction& op)
       auto texCoord = loadSrcModified(builder, op, src0, ComponentBit::eAll, scalarType);
       texCoord = swizzleVector(builder, texCoord, swizzle, ComponentBit::eAll);
       uint32_t samplerIdx = dst.getIndex();
-
-      if (m_parser.getShaderInfo().getVersion().first <= 1u && m_parser.getShaderInfo().getVersion().second < 4u)
-        texCoord = m_resources.projectTexCoord(builder, samplerIdx, texCoord, true);
 
       result = m_resources.emitSample(builder, samplerIdx, texCoord, ir::SsaDef(), ir::SsaDef(), ir::SsaDef(), ir::SsaDef(), scalarType);
     } break;

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -947,11 +947,19 @@ ir::SsaDef Converter::loadSrc(ir::Builder& builder, const Instruction& op, const
 
     case RegisterType::eAddr:
     /* case RegisterType::eTexture: Same Value */
-      if (getShaderInfo().getType() == ShaderType::eVertex)
+      if (getShaderInfo().getType() == ShaderType::eVertex) {
         /* RegisterType::eAddr */
         logOpError(op, "Address register cannot be loaded as a regular source register.");
-      else
+      } else if (getShaderInfo().getVersion().first == 1u && getShaderInfo().getVersion().second <= 3u) {
+        /* Texture registers act as special purpose temp registers in PS 1.1 - PS 1.3. */
+        loadDef = m_regFile.emitTextureRegLoad(builder,
+          operand.getIndex(),
+          swizzle,
+          mask,
+          type);
+      } else {
         loadDef = m_ioMap.emitLoad(builder, op, operand, mask, swizzle, type); /* RegisterType::eTexture */
+      }
       break;
 
     case RegisterType::eTemp:
@@ -1179,13 +1187,8 @@ bool Converter::storeDst(ir::Builder& builder, const Instruction& op, const Oper
 
   switch (operand.getRegisterType()) {
     case RegisterType::eTemp:
-      return m_regFile.emitStore(builder, operand, writeMask, predicateVec, value);
-
     case RegisterType::eAddr:
-      if (getShaderInfo().getType() == ShaderType::eVertex)
-        return m_regFile.emitStore(builder, operand, writeMask, predicateVec, value);
-      else
-        return m_ioMap.emitStore(builder, op, operand, writeMask, predicateVec, value);
+      return m_regFile.emitStore(builder, operand, writeMask, predicateVec, value);
 
     case RegisterType::eOutput:
     case RegisterType::eRasterizerOut:

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -774,6 +774,30 @@ bool IoMap::emitDepthStore(ir::Builder &builder, const Instruction &op, ir::SsaD
 }
 
 
+bool IoMap::emitColorStore(ir::Builder& builder, ir::SsaDef value) {
+  const IoVarInfo* ioVar = findIoVar(m_variables, RegisterType::eColorOut, 0u);
+
+  if (ioVar == nullptr) {
+    std::optional<Semantic> semantic = determineSemanticForRegister(RegisterType::eColorOut, 0u);
+
+    if (!semantic.has_value()) {
+      Logger::err("Failed to process I/O color store.");
+      return false;
+    }
+
+    dclIoVar(builder, RegisterType::eColorOut, 0u, semantic.value());
+    ioVar = &m_variables.back();
+  }
+
+  for (uint32_t i = 0u; i < 4u; i++) {
+    auto valueScalar = ir::extractFromVector(builder, value, i);
+    dxbc_spv_assert(builder.getOp(ioVar->tempDefs[i]).getType() == builder.getOp(valueScalar).getType());
+    builder.add(ir::Op::TmpStore(ioVar->tempDefs[i], valueScalar));
+  }
+  return true;
+}
+
+
 ir::SsaDef IoMap::emitDynamicLoadFunction(ir::Builder& builder) const {
   auto indexParameter = builder.add(ir::Op::DclParam(ir::ScalarType::eU32));
 

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -357,12 +357,7 @@ void IoMap::dclIoVar(
   if (builtIn == ir::BuiltIn::ePointSize)
     tempVectorSize = 4u;
 
-  auto [versionMajor, versionMinor] = m_converter.getShaderInfo().getVersion();
-
-  if (!isInput || (registerType == RegisterType::eTexture
-    && versionMajor == 1u
-    && versionMinor < 4u
-    && shaderType == ShaderType::ePixel)) {
+  if (!isInput) {
     /* SM 1 texture ops write the texture data into the texture register which used to hold the texcoord.
      * So we need writable temps for this input register. */
     for (uint32_t i = 0u; i < tempVectorSize; i++) {
@@ -628,15 +623,9 @@ ir::SsaDef IoMap::emitTexCoordLoad(
     }
 
     auto varScalarType = ioVar->baseType.getBaseType(0u).getBaseType();
-    ir::SsaDef value;
 
-    if (!ioVar->tempDefs[0u]) {
-      ir::SsaDef addressConstant = builder.makeConstant(componentIndex);
-      value = builder.add(ir::Op::InputLoad(varScalarType, ioVar->baseDef, addressConstant));
-    } else {
-      /* The input register is writable. (SM 1 Texture register) */
-      value = builder.add(ir::Op::TmpLoad(varScalarType, ioVar->tempDefs[uint32_t(componentIndex)]));
-    }
+    ir::SsaDef addressConstant = builder.makeConstant(componentIndex);
+    auto value = builder.add(ir::Op::InputLoad(varScalarType, ioVar->baseDef, addressConstant));
 
     components[componentIndex] = convertScalar(builder, type, value);
   }
@@ -673,16 +662,7 @@ bool IoMap::emitStore(
       emitIoVarDefault(builder, *ioVar);
     }
 
-    if (operand.getRegisterType() == RegisterType::eTexture) {
-      /* PS 1 texture registers hold the texcoords at first which then gets replaced by the texture data when
-       * a texture sampling instruction is executed. */
-      dxbc_spv_assert(m_converter.getShaderInfo().getType() == ShaderType::ePixel);
-      auto [versionMajor, versionMinor] = m_converter.getShaderInfo().getVersion();
-      dxbc_spv_assert(versionMajor <= 1u && versionMinor <= 3u);
-    } else {
-      bool isOutput = !registerTypeIsInput(ioVar->registerType, m_converter.getShaderInfo().getType());
-      dxbc_spv_assert(isOutput);
-    }
+    dxbc_spv_assert(!registerTypeIsInput(ioVar->registerType, m_converter.getShaderInfo().getType()));
 
     auto ioVarBaseType = ioVar->baseType.getBaseType(0u);
     ir::ScalarType ioVarScalarType = ioVarBaseType.getBaseType();

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -126,6 +126,9 @@ public:
     const Instruction&            op,
           ir::SsaDef              value);
 
+  /** Stores a vector value to color output register 0. */
+  bool emitColorStore(ir::Builder& builder, ir::SsaDef value);
+
 private:
 
   Converter&      m_converter;

--- a/sm3/sm3_registers.cpp
+++ b/sm3/sm3_registers.cpp
@@ -10,9 +10,11 @@ RegisterFile::RegisterFile(Converter &converter)
 : m_converter(converter) {
 }
 
+
 RegisterFile::~RegisterFile() {
 
 }
+
 
 void RegisterFile::initialize(ir::Builder& builder) {
   uint32_t addressRegisterComponents = m_converter.getShaderInfo().getVersion().first >= 2u ? 4u : 1u;
@@ -43,6 +45,7 @@ void RegisterFile::initialize(ir::Builder& builder) {
   }
 }
 
+
 ir::SsaDef RegisterFile::getOrDeclareTemp(ir::Builder& builder, uint32_t index, Component component) {
   uint32_t tempIndex = 4u * index + uint8_t(component);
 
@@ -61,6 +64,23 @@ ir::SsaDef RegisterFile::getOrDeclareTemp(ir::Builder& builder, uint32_t index, 
   return m_rRegs[tempIndex];
 }
 
+
+ir::SsaDef RegisterFile::getOrDeclareTextureReg(ir::Builder& builder, uint32_t index, Component component) {
+  uint32_t textureIndex = 4u * index + uint8_t(component);
+
+  if (!m_textureRegs[textureIndex]) {
+    m_textureRegs[textureIndex] = builder.add(ir::Op::DclTmp(ir::ScalarType::eUnknown, m_converter.getEntryPoint()));
+
+    if (m_converter.getOptions().includeDebugNames) {
+      std::string name = m_converter.makeRegisterDebugName(RegisterType::eTexture, index, util::componentBit(component));
+      builder.add(ir::Op::DebugName(m_textureRegs[textureIndex], name.c_str()));
+    }
+  }
+
+  return m_textureRegs[textureIndex];
+}
+
+
 ir::SsaDef RegisterFile::emitTempLoad(
   ir::Builder& builder,
   uint32_t regIndex,
@@ -77,6 +97,33 @@ ir::SsaDef RegisterFile::emitTempLoad(
 
     auto tmpReg = getOrDeclareTemp(builder, regIndex, component);
     auto scalar = builder.add(ir::Op::TmpLoad(ir::ScalarType::eUnknown, tmpReg));
+
+    /* Convert to requested type */
+    scalar = builder.add(ir::Op::ConsumeAs(type, scalar));
+
+    components[uint8_t(component)] = scalar;
+  }
+
+  return composite(builder, returnType, components.data(), swizzle, componentMask);
+}
+
+
+ir::SsaDef RegisterFile::emitTextureRegLoad(
+    ir::Builder& builder,
+    uint32_t regIndex,
+    Swizzle swizzle,
+    WriteMask componentMask,
+    ir::ScalarType type
+  ) {
+  auto returnType = makeVectorType(type, componentMask);
+
+  std::array<ir::SsaDef, 4u> components = { };
+
+  for (auto c : swizzle.getReadMask(componentMask)) {
+    auto component = componentFromBit(c);
+
+    auto texReg = getOrDeclareTextureReg(builder, regIndex, component);
+    auto scalar = builder.add(ir::Op::TmpLoad(ir::ScalarType::eUnknown, texReg));
 
     /* Convert to requested type */
     scalar = builder.add(ir::Op::ConsumeAs(type, scalar));
@@ -164,20 +211,30 @@ bool RegisterFile::emitStore(
           scalar = builder.add(ir::Op::ConsumeAs(ir::ScalarType::eUnknown, scalar));
       } break;
 
-      case RegisterType::eAddr: {
-        dxbc_spv_assert(m_converter.getShaderInfo().getVersion().first >= 2u || c == ComponentBit::eX);
-        dxbc_spv_assert(m_converter.getShaderInfo().getType() == ShaderType::eVertex);
+      case RegisterType::eAddr:
+      /* case RegisterType::eTexture: Same Value */ {
 
-        if (!valueType.isIntType()) {
-          /* a0 can be written to using the mova instruction on SM2+
-           * or the mov instruction on SM1.1. */
+        /* Vertex shaders use this register type value for address */
+        if (m_converter.getShaderInfo().getType() == ShaderType::eVertex) {
+          dxbc_spv_assert(m_converter.getShaderInfo().getVersion().first >= 2u || c == ComponentBit::eX);
 
-          scalar = builder.add(ir::Op::ConsumeAs(ir::ScalarType::eF32, scalar));
-          scalar = builder.add(ir::Op::FRound(ir::ScalarType::eF32, scalar, ir::RoundMode::eNearestEven));
-          scalar = builder.add(ir::Op::ConvertFtoI(ir::ScalarType::eI32, scalar));
+          if (!valueType.isIntType()) {
+            /* a0 can be written to using the mova instruction on SM2+
+             * or the mov instruction on SM1.1. */
+
+            scalar = builder.add(ir::Op::ConsumeAs(ir::ScalarType::eF32, scalar));
+            scalar = builder.add(ir::Op::FRound(ir::ScalarType::eF32, scalar, ir::RoundMode::eNearestEven));
+            scalar = builder.add(ir::Op::ConvertFtoI(ir::ScalarType::eI32, scalar));
+          }
+
+          reg = m_a0Reg[uint8_t(component)];
+        } else {
+          /* Texture registers act as special purpose temp registers in PS 1.1 - PS 1.3. */
+          reg = getOrDeclareTextureReg(builder, regIndex, component);
+
+          if (!valueType.isUnknownType())
+            scalar = builder.add(ir::Op::ConsumeAs(ir::ScalarType::eUnknown, scalar));
         }
-
-        reg = m_a0Reg[uint8_t(component)];
       } break;
 
       case RegisterType::ePredicate: {

--- a/sm3/sm3_registers.h
+++ b/sm3/sm3_registers.h
@@ -52,9 +52,19 @@ public:
   void emitBufferedStores(
           ir::Builder&            builder);
 
+  /** Loads value from texture register. */
+  ir::SsaDef emitTextureRegLoad(
+          ir::Builder&            builder,
+          uint32_t                regIndex,
+          Swizzle                 swizzle,
+          WriteMask               componentMask,
+          ir::ScalarType          type);
+
 private:
 
   ir::SsaDef getOrDeclareTemp(ir::Builder& builder, uint32_t index, Component component);
+
+  ir::SsaDef getOrDeclareTextureReg(ir::Builder& builder, uint32_t index, Component component);
 
   Converter& m_converter;
 
@@ -80,6 +90,9 @@ private:
 
   /* Buffered stores to deal with coissue */
   util::small_vector<Store, 8u> m_stores = { };
+
+  /* In shader model 1.1 - 1.3, you put either texture data (from sampling) or texcoords into a texture register. */
+  std::array<ir::SsaDef, 8u * 4u> m_textureRegs = { };
 
 };
 


### PR DESCRIPTION
Texture registers in SM1 are much more similar to temp registers so they should be implemented similarly.

Besides that, this PR restricts `D3DTTFF_PROJECTED` to the PS 1_1 - PS 1_3 `tex` instruction. Tests on Windows show that it doesn't impact instructions like `texcoord` and doesn't impact instructions that use multiple texture registers like `texdp3` besides the fact that those use a texture register as input and that must have been initialized before (like with `tex`).

As a third thing, this PR fixes outputs on SM1. That's simply something I noticed while testing the changes.

After that I plan to finally land #45. Now that I actually know which instructions are impacted by `D3DTTFF_PROJECTED`.