### PR TITLE
Shader Model 1-3: Fix copying operands.

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -246,7 +246,7 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
 
 
 bool Converter::finalize(ir::Builder& builder, ShaderType shaderType) {
-  if (getShaderInfo().getVersion().first == 1u) {
+  if (shaderType == ShaderType::ePixel && getShaderInfo().getVersion().first == 1u) {
     /* Shader model 1 doesn't have special color output registers.
      * Instead, it simply outputs what was in Temp register 0 (r0) at the end. */
     auto value = m_regFile.emitTempLoad(builder, 0u,

--- a/sm3/sm3_parser.h
+++ b/sm3/sm3_parser.h
@@ -412,7 +412,9 @@ public:
   /** Returns a new operand with a specific register index */
   Operand withIndex(uint32_t index) {
     uint32_t token = util::binsert(m_token, index, 0u, 11u);
-    return Operand(token, m_info);
+    Operand result = *this;
+    result.m_token = token;
+    return result;
   }
 
   /** Writes code header to binary blob. */
@@ -424,10 +426,6 @@ public:
   }
 
 private:
-
-  Operand(uint32_t token, OperandInfo info)
-    : m_token(token)
-    , m_info(info) { }
 
   uint32_t                  m_token   = { };
 


### PR DESCRIPTION
The matrix instructions (`m3x4`, etc) load additional registers beyond the ones that are specified as sources. Because of that we copy the `Operator` instance and change the index. Unfortunately we didn't copy all of it. The extra relative addressing token was missing for example. That's especially problematic because we base the decision whether an operand has relative addressing on the opcode, operand type and on a bit in the main token.
So in the end, a shader in Guild Wars 1 tried to read the relative addressing token which was missing. This lead to a crash.

(https://github.com/K0bin/dxbc-spirv/issues/2)

This PR fixes the crash.