### PR TITLE
Shader Model 1-3: Implement some missing tricks for point sprites

### DIFF
--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -499,6 +499,7 @@ std::ostream& operator << (std::ostream& os, const BuiltIn& builtIn) {
     case BuiltIn::eLocalThreadIndex:    return os << "LocalThreadIndex";
     case BuiltIn::ePointSize:           return os << "PointSize";
     case BuiltIn::eTessFactorLimit:     return os << "TessFactorLimit";
+    case BuiltIn::ePointCoord:          return os << "PointCoord";
   }
 
   return os << "BuiltIn(" << uint32_t(builtIn) << ")";

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -717,6 +717,8 @@ enum class BuiltIn : uint32_t {
   ePointSize          = 27u,
   /** Maximum tessellation factor */
   eTessFactorLimit    = 28u,
+  /** Coordinate of a fragment within a point */
+  ePointCoord         = 29u,
 };
 
 

--- a/ir/ir_divergence.cpp
+++ b/ir/ir_divergence.cpp
@@ -518,6 +518,7 @@ Scope DivergenceAnalysis::determineScopeForBuiltIn(const Op& op) {
     case BuiltIn::eTessCoord:
     case BuiltIn::eSampleMask:
     case BuiltIn::eIsFullyCovered:
+    case BuiltIn::ePointCoord:
       return Scope::eThread;
 
     /* Per-primitive inputs, including in geometry stages. Use quad scope

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -273,6 +273,8 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
     m_psSharedData = emitSharedConstants(builder);
   }
 
+  m_renderState = emitRenderStatePushData(builder);
+
   /* Set cursor to main function so that instructions will be emitted
    * in the correct location */
   builder.setCursor(m_entryPoint.mainFunc);
@@ -364,6 +366,57 @@ ir::SsaDef Converter::emitSharedConstants(ir::Builder& builder) {
   }
 
   return buffer;
+}
+
+
+ir::SsaDef Converter::emitRenderStatePushData(ir::Builder& builder) {
+  /*
+   * struct RenderState {
+   *     vec3 fogColor;
+   *     float fogScale;
+   *     float fogEnd;
+   *     float fogDensity;
+   *     uint alphaRef;
+   *     float pointSize;
+   *     float pointSizeMin;
+   *     float pointSizeMax;
+   *     float pointScaleA;
+   *     float pointScaleB;
+   *     float pointScaleC;
+   * }
+   */
+  ir::Type bufferStruct = ir::Type();
+  bufferStruct.addStructMember(ir::BasicType(ir::ScalarType::eF32, 3u));
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eU32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+  bufferStruct.addStructMember(ir::ScalarType::eF32);
+
+  auto pushData = builder.add(ir::Op::DclPushData(bufferStruct, getEntryPoint(), 0u,
+    ir::ShaderStage::eVertex | ir::ShaderStage::ePixel));
+
+  if (getOptions().includeDebugNames) {
+    builder.add(ir::Op::DebugName(pushData, "RenderState"));
+    builder.add(ir::Op::DebugMemberName(pushData, 0u, "fogColor"));
+    builder.add(ir::Op::DebugMemberName(pushData, 1u, "fogScale"));
+    builder.add(ir::Op::DebugMemberName(pushData, 2u, "fogEnd"));
+    builder.add(ir::Op::DebugMemberName(pushData, 3u, "fogDensity"));
+    builder.add(ir::Op::DebugMemberName(pushData, 4u, "alphaRef"));
+    builder.add(ir::Op::DebugMemberName(pushData, 5u, "pointSize"));
+    builder.add(ir::Op::DebugMemberName(pushData, 6u, "pointSizeMin"));
+    builder.add(ir::Op::DebugMemberName(pushData, 7u, "pointSizeMax"));
+    builder.add(ir::Op::DebugMemberName(pushData, 8u, "pointScaleA"));
+    builder.add(ir::Op::DebugMemberName(pushData, 9u, "pointScaleB"));
+    builder.add(ir::Op::DebugMemberName(pushData, 10u, "pointScaleC"));
+  }
+
+  return pushData;
 }
 
 

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -71,6 +71,7 @@ private:
   SpecializationConstantsMap m_specConstants;
 
   ir::SsaDef       m_psSharedData;
+  ir::SsaDef       m_renderState;
 
   uint32_t m_instructionCount = 0u;
 
@@ -125,6 +126,8 @@ private:
   ir::SsaDef emitTexMatMul(ir::Builder& builder, const Instruction& op);
 
   ir::SsaDef emitSharedConstants(ir::Builder& builder);
+
+  ir::SsaDef emitRenderStatePushData(ir::Builder& builder);
 
   ir::SsaDef applyBumpMapping(ir::Builder& builder, uint32_t stageIdx, ir::SsaDef src0, ir::SsaDef src1);
 

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -421,6 +421,16 @@ void IoMap::emitIoVarDefault(
       for (uint32_t i = 0u; i < ioVarType.getVectorSize(); i++) {
         builder.add(ir::Op::TmpStore(ioVar.tempDefs[i], builder.makeConstant(i == 3u ? 1.0f : 0.0f)));
       }
+    } else if (ioVar.semantic.usage == SemanticUsage::ePointSize) {
+      auto pointSize = builder.add(ir::Op::PushDataLoad(ir::ScalarType::eF32, m_converter.m_renderState,
+        builder.makeConstant(5u)));
+      auto pointSizeMin = builder.add(ir::Op::PushDataLoad(ir::ScalarType::eF32, m_converter.m_renderState,
+        builder.makeConstant(6u)));
+      auto pointSizeMax = builder.add(ir::Op::PushDataLoad(ir::ScalarType::eF32, m_converter.m_renderState,
+        builder.makeConstant(7u)));
+
+      auto finalSize = builder.add(ir::Op::FClamp(ir::ScalarType::eF32, pointSize, pointSizeMin, pointSizeMax));
+      builder.add(ir::Op::TmpStore(ioVar.tempDefs[0], finalSize));
     } else {
       /* The default for other registers is 0.0, 0.0, 0.0, 0.0 */
       for (uint32_t i = 0u; i < ioVarType.getVectorSize(); i++) {
@@ -683,6 +693,13 @@ bool IoMap::emitStore(
         /* The color register cannot be dynamically indexed, so there's no need to do this in the dynamic store function. */
         valueScalar = builder.add(ir::Op::FClamp(ioVarScalarType, valueScalar,
           builder.makeConstant(0.0f), builder.makeConstant(1.0f)));
+      } else if (ioVar->semantic.usage == SemanticUsage::ePointSize) {
+        /* Clamp value between D3DRS_POINTSIZE_MIN and D3DRS_POINTSIZE_MAX. */
+        auto pointSizeMin = builder.add(ir::Op::PushDataLoad(ir::ScalarType::eF32, m_converter.m_renderState,
+          builder.makeConstant(6u)));
+        auto pointSizeMax = builder.add(ir::Op::PushDataLoad(ir::ScalarType::eF32, m_converter.m_renderState,
+          builder.makeConstant(7u)));
+        valueScalar = builder.add(ir::Op::FClamp(ioVarScalarType, valueScalar, pointSizeMin, pointSizeMax));
       }
 
       if (predicateVec) {

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -111,6 +111,9 @@ void IoMap::initialize(ir::Builder& builder) {
         0u,
         { SemanticUsage::eColor, 0u }
       );
+
+      /* Declare the point coord built-in because we might need that for the texcoord register. */
+      dclPointCoord(builder);
     }
   }
 }
@@ -391,6 +394,21 @@ void IoMap::dclIoVar(
 }
 
 
+void IoMap::dclPointCoord(ir::Builder& builder) {
+  auto type = ir::BasicType(ir::ScalarType::eF32, 2u);
+  m_pointCoord = builder.add(ir::Op::DclInputBuiltIn(type, m_converter.getEntryPoint(), ir::BuiltIn::ePointCoord));
+}
+
+
+ir::SsaDef IoMap::emitPointCoordLoad(ir::Builder& builder) {
+  auto pointCoordType = ir::BasicType(ir::ScalarType::eF32, 2u);
+  auto pointCoord = builder.add(ir::Op::InputLoad(pointCoordType, m_pointCoord, ir::SsaDef()));
+  /* Turn it into a vec4 so it can easily be used as the texcoord register value. */
+  std::array<ir::SsaDef, 4u> components = { pointCoord, pointCoord, builder.makeConstant(0.0f), builder.makeConstant(0.0f) };
+  return ir::buildVector(builder, ir::ScalarType::eF32, 4u, components.data());
+}
+
+
 void IoMap::emitIoVarDefaults(ir::Builder& builder) {
   for (const IoVarInfo& ioVar : m_variables) {
     emitIoVarDefault(builder, ioVar);
@@ -555,6 +573,26 @@ ir::SsaDef IoMap::emitLoad(
             addressConstant = builder.makeConstant(uint32_t(componentIndex));
 
           value = builder.add(ir::Op::InputLoad(varScalarType, ioVar->baseDef, addressConstant));
+
+          if (m_converter.getShaderInfo().getType() == ShaderType::ePixel
+            && ioVar->registerType == RegisterType::eInput
+            && ioVar->semantic.usage == SemanticUsage::eTexCoord) {
+            /* We need to replace TEXCOORD inputs with gl_PointCoord
+             * if D3DRS_POINTSPRITEENABLE is set. */
+            auto pointCoord = emitPointCoordLoad(builder);
+
+            auto specConstBit = m_converter.m_specConstants.get(builder, SpecConstantId::eSpecPointMode,
+              builder.makeConstant(1u), builder.makeConstant(1u));
+            auto pointSpriteEnabled = builder.add(ir::Op::IEq(ir::ScalarType::eU32, specConstBit, builder.makeConstant(1u)));
+
+            value = builder.add(ir::Op::Select(
+              ir::BasicType(ir::ScalarType::eF32, 4u),
+              pointSpriteEnabled,
+              pointCoord,
+              value
+            ));
+          }
+
         } else {
           /* The input register is writable. (SM 1 Texture register) */
           value = builder.add(ir::Op::TmpLoad(varScalarType, ioVar->tempDefs[uint32_t(componentIndex)]));

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -140,6 +140,8 @@ private:
   ir::SsaDef      m_inputSwitchFunction = { };
   ir::SsaDef      m_outputSwitchFunction = { };
 
+  ir::SsaDef      m_pointCoord;
+
   ir::SsaDef emitDynamicLoadFunction(ir::Builder& builder) const;
   ir::SsaDef emitDynamicStoreFunction(ir::Builder& builder) const;
 
@@ -163,6 +165,10 @@ private:
     RegisterType registerType,
     uint32_t     registerIndex,
     Semantic     semantic);
+
+  void dclPointCoord(ir::Builder& builder);
+
+  ir::SsaDef emitPointCoordLoad(ir::Builder& builder);
 
   /** Turns a front face boolean into a float. 1.0 for the front face, -1.0 for the back face. */
   ir::SsaDef emitFrontFaceFloat(ir::Builder& builder, ir::SsaDef isFrontFaceDef) const;

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -1048,6 +1048,9 @@ void SpirvBuilder::emitDclBuiltInIoVar(const ir::Op& op) {
       case ir::BuiltIn::eTessFactorLimit:
         /* Handled elsewhere */
         break;
+
+      case ir::BuiltIn::ePointCoord:
+        return spv::BuiltInPointCoord;
     }
 
     dxbc_spv_unreachable();


### PR DESCRIPTION
Implements some of the missing tricks that the current DXVK compiler does to implement D3D9 point sprites.