### PR TITLE
Shader Model 1-3: Remaining preparation before setup in DXVK

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -2247,7 +2247,7 @@ void Converter::emitAlphaTest(ir::Builder& builder) {
   auto alphaTestBoolTmp = builder.add(ir::Op::DclTmp(ir::ScalarType::eBool, m_entryPoint.def));
 
   auto switchDef = builder.add(ir::Op::ScopedSwitch(ir::SsaDef(), alphaComparisonMode));
-  for (uint32_t i = 0u; i <= uint(AlphaTestComparisonMode::eAlways); i++) {
+  for (uint32_t i = 0u; i <= uint32_t(AlphaTestComparisonMode::eAlways); i++) {
     builder.add(ir::Op::ScopedSwitchCase(switchDef, i));
 
     ir::Op comparisonOp;

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -286,6 +286,9 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
        * So there's no code needed in vertex shaders. */
       emitFog(builder);
     }
+  } else {
+    m_clipPlanes = emitClipPlanes(builder);
+    emitClipping(builder);
   }
 
   /* Set cursor to main function so that instructions will be emitted
@@ -325,6 +328,12 @@ bool Converter::finalize(ir::Builder& builder, ShaderType shaderType) {
       if (!m_ioMap.emitColorStore(builder, colorWithFog))
         return false;
     }
+  } else {
+    auto position = m_ioMap.getPositionValue(builder);
+    builder.add(
+      ir::Op::FunctionCall(ir::ScalarType::eVoid, m_clippingFunction)
+      .addParam(position)
+    );
   }
 
   m_ioMap.finalize(builder);
@@ -450,6 +459,22 @@ ir::SsaDef Converter::emitRenderStatePushData(ir::Builder& builder) {
   }
 
   return pushData;
+}
+
+
+ir::SsaDef Converter::emitClipPlanes(ir::Builder& builder) {
+  dxbc_spv_assert(getShaderInfo().getType() == ShaderType::eVertex);
+
+  /* Declare Cbv containing clip planes */
+  auto clipPlaneArrayType = ir::Type(ir::BasicType(ir::ScalarType::eF32, 4u));
+  clipPlaneArrayType.addArrayDimension(MaxClipPlanes);
+  auto clipPlaneBlock = builder.add(ir::Op::DclCbv(clipPlaneArrayType, getEntryPoint(),
+    0u, VSClipPlanesCbvRegIdx, 1u));
+
+  if (getOptions().includeDebugNames)
+    builder.add(ir::Op::DebugName(clipPlaneBlock, "ClipPlanes"));
+
+  return clipPlaneBlock;
 }
 
 
@@ -2405,6 +2430,41 @@ void Converter::emitFog(ir::Builder& builder) {
     finalColorComponents.data());
 
   builder.add(ir::Op::Return(ir::BasicType(ir::ScalarType::eF32, 4u), finalColor4));
+  builder.add(ir::Op::FunctionEnd());
+}
+
+
+void Converter::emitClipping(ir::Builder& builder) {
+  auto vec4Type = ir::BasicType(ir::ScalarType::eF32, 4u);
+
+  auto positionParam = builder.add(ir::Op::DclParam(vec4Type));
+  auto returnType = ir::BasicType(ir::ScalarType::eF32, 4u);
+
+  auto functionOp = ir::Op::Function(returnType)
+      .addOperand(positionParam);
+
+  m_clippingFunction = builder.add(functionOp);
+
+  if (getOptions().includeDebugNames) {
+    builder.add(ir::Op::DebugName(m_clippingFunction, "clipping"));
+    builder.add(ir::Op::DebugName(positionParam, "position"));
+  }
+
+  // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
+  auto clipPlaneCount = m_specConstants.get(builder, SpecConstantId::eSpecClipPlaneCount);
+
+  auto position = builder.add(ir::Op::ParamLoad(vec4Type, m_clippingFunction, positionParam));
+
+  for (uint32_t i = 0u; i < MaxClipPlanes; i++) {
+    auto descriptor = builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eCbv, m_clipPlanes, builder.makeConstant(0u)));
+    auto clipPlane = builder.add(ir::Op::BufferLoad(vec4Type, descriptor, builder.makeConstant(i), 16u));
+    auto dist = builder.add(emitFDot(ir::ScalarType::eF32, position, clipPlane));
+
+    auto clipPlaneEnabled = builder.add(ir::Op::ULt(ir::ScalarType::eBool, builder.makeConstant(i), clipPlaneCount));
+    auto value = builder.add(ir::Op::Select(ir::ScalarType::eF32, clipPlaneEnabled, dist, builder.makeConstant(0.0f)));
+    m_ioMap.emitClipPlaneStore(builder, i, value);
+  }
+
   builder.add(ir::Op::FunctionEnd());
 }
 

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -72,9 +72,11 @@ private:
 
   ir::SsaDef       m_psSharedData;
   ir::SsaDef       m_renderState;
+  ir::SsaDef       m_clipPlanes = { };
 
   ir::SsaDef       m_alphaTestFunction;
   ir::SsaDef       m_fogFunction = { };
+  ir::SsaDef       m_clippingFunction = { };
 
   uint32_t m_instructionCount = 0u;
 
@@ -131,6 +133,8 @@ private:
   ir::SsaDef emitSharedConstants(ir::Builder& builder);
 
   ir::SsaDef emitRenderStatePushData(ir::Builder& builder);
+
+  ir::SsaDef emitClipPlanes(ir::Builder& builder);
 
   ir::SsaDef applyBumpMapping(ir::Builder& builder, uint32_t stageIdx, ir::SsaDef src0, ir::SsaDef src1);
 
@@ -217,6 +221,8 @@ private:
   void emitAlphaTest(ir::Builder& builder);
 
   void emitFog(ir::Builder& builder);
+
+  void emitClipping(ir::Builder& builder);
 
   void emitFloatModes(ir::Builder& builder);
 

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -130,6 +130,8 @@ void IoMap::initialize(ir::Builder& builder) {
   if (m_converter.getShaderInfo().getType() == ShaderType::ePixel) {
     /* Declare the point coord built-in because we might need that for the texcoord register. */
     dclPointCoord(builder);
+  } else {
+    dclClipPlanes(builder);
   }
 }
 
@@ -151,9 +153,6 @@ void IoMap::finalize(ir::Builder& builder) {
     m_outputSwitchFunction = outputSwitchFunction;
     builder.setCursor(cursor);
   }
-
-  if (m_converter.getShaderInfo().getType() == ShaderType::eVertex)
-    emitVSClipping(builder);
 
   flushOutputs(builder);
 }
@@ -957,6 +956,15 @@ ir::SsaDef IoMap::getPositionValue(ir::Builder& builder) {
 }
 
 
+void IoMap::emitClipPlaneStore(ir::Builder& builder, uint32_t index, ir::SsaDef value) {
+  dxbc_spv_assert(m_converter.getShaderInfo().getType() == ShaderType::eVertex);
+  dxbc_spv_assert(m_clipDistances);
+  dxbc_spv_assert(index < MaxClipPlanes);
+
+  builder.add(ir::Op::OutputStore(m_clipDistances, builder.makeConstant(index), value));
+}
+
+
 ir::SsaDef IoMap::emitDynamicLoadFunction(ir::Builder& builder) const {
   auto indexParameter = builder.add(ir::Op::DclParam(ir::ScalarType::eU32));
 
@@ -1107,17 +1115,8 @@ ir::SsaDef IoMap::emitFrontFaceFloat(ir::Builder &builder, ir::SsaDef isFrontFac
 }
 
 
-void IoMap::emitVSClipping(ir::Builder& builder) {
-  auto vec4Type = ir::BasicType(ir::ScalarType::eF32, 4u);
-
-  /* Declare Cbv containing clip planes */
-  auto clipPlaneArrayType = ir::Type(vec4Type);
-  clipPlaneArrayType.addArrayDimension(MaxClipPlanes);
-  auto clipPlaneBlock = builder.add(ir::Op::DclCbv(clipPlaneArrayType, m_converter.getEntryPoint(),
-    0u, VSClipPlanesCbvRegIdx, 1u));
-
-  if (m_converter.getOptions().includeDebugNames)
-    builder.add(ir::Op::DebugName(clipPlaneBlock, "ClipPlanes"));
+void IoMap::dclClipPlanes(ir::Builder& builder) {
+  dxbc_spv_assert(m_converter.getShaderInfo().getType() == ShaderType::eVertex);
 
   /* Declare output array for clip distances */
   auto clipDistanceArrayType = ir::Type(ir::ScalarType::eF32);
@@ -1125,33 +1124,7 @@ void IoMap::emitVSClipping(ir::Builder& builder) {
   auto clipDistancesArrayOp = ir::Op::DclOutputBuiltIn(clipDistanceArrayType,
     m_converter.getEntryPoint(), ir::BuiltIn::eClipDistance);
   clipDistancesArrayOp.setFlags(ir::OpFlag::eInvariant);
-  auto clipDistanceArray = builder.add(clipDistancesArrayOp);
-
-  const IoVarInfo* positionVar = findIoVar({ SemanticUsage::ePosition, 0u }, false);
-
-  dxbc_spv_assert(positionVar != nullptr);
-  dxbc_spv_assert(positionVar->baseType == ir::BasicType(ir::ScalarType::eF32, 4u));
-
-  std::array<ir::SsaDef, 4u> components;
-  for (uint32_t i = 0u; i < 4u; i++) {
-    dxbc_spv_assert(positionVar->tempDefs[i]);
-    components[i] = builder.add(ir::Op::TmpLoad(positionVar->baseType, positionVar->tempDefs[i]));
-  }
-
-  // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
-  auto clipPlaneCount = m_converter.m_specConstants.get(builder, SpecConstantId::eSpecClipPlaneCount);
-
-  auto position = ir::buildVector(builder, ir::ScalarType::eF32, components.size(), components.data());
-
-  for (uint32_t i = 0u; i < MaxClipPlanes; i++) {
-    auto descriptor = builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eCbv, clipPlaneBlock, builder.makeConstant(0u)));
-    auto clipPlane = builder.add(ir::Op::BufferLoad(vec4Type, descriptor, builder.makeConstant(i), 16u));
-    auto dist = builder.add(m_converter.emitFDot(ir::ScalarType::eF32, position, clipPlane));
-
-    auto clipPlaneEnabled = builder.add(ir::Op::ULe(ir::ScalarType::eBool, builder.makeConstant(i), clipPlaneCount));
-    auto value = builder.add(ir::Op::Select(ir::ScalarType::eF32, clipPlaneEnabled, dist, builder.makeConstant(0.0f)));
-    builder.add(ir::Op::OutputStore(clipDistanceArray, builder.makeConstant(i), value));
-  }
+  m_clipDistances = builder.add(clipDistancesArrayOp);
 }
 
 

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -139,6 +139,8 @@ public:
 
   ir::SsaDef getPositionValue(ir::Builder& builder);
 
+  void emitClipPlaneStore(ir::Builder& builder, uint32_t index, ir::SsaDef value);
+
 private:
 
   Converter&      m_converter;
@@ -151,6 +153,8 @@ private:
   ir::SsaDef      m_outputSwitchFunction = { };
 
   ir::SsaDef      m_pointCoord = { };
+
+  ir::SsaDef      m_clipDistances = { };
 
   ir::SsaDef emitDynamicLoadFunction(ir::Builder& builder) const;
   ir::SsaDef emitDynamicStoreFunction(ir::Builder& builder) const;
@@ -183,7 +187,7 @@ private:
   /** Turns a front face boolean into a float. 1.0 for the front face, -1.0 for the back face. */
   ir::SsaDef emitFrontFaceFloat(ir::Builder& builder, ir::SsaDef isFrontFaceDef) const;
 
-  void emitVSClipping(ir::Builder& builder);
+  void dclClipPlanes(ir::Builder& builder);
 
   /** Looks up matching I/O variable in the given list. */
   const IoVarInfo* findIoVar(RegisterType regType, uint32_t regIndex) const;

--- a/sm3/sm3_parser.h
+++ b/sm3/sm3_parser.h
@@ -633,6 +633,12 @@ public:
 
   Instruction parseInstruction();
 
+  /** Queries the current offset.
+   * If we are past the end, this is the bytecode length of the shader. */
+  size_t getByteOffset() const {
+    return m_reader.getOffset();
+  }
+
   /** Checks whether any more instructions are
    *  available to be parsed. */
   explicit operator bool () const {

--- a/sm3/sm3_parser.h
+++ b/sm3/sm3_parser.h
@@ -500,15 +500,23 @@ public:
     if (m_operands.empty())
       return 0u;
 
+    /* Instructions, that have immediate operands, don't have src operands.
+     * Comments are a special case. */
+    if (hasImm() || getOpCode() == OpCode::eComment)
+      return 0u;
+
     /* Src operands can come with a dst operand (but never with anything else) */
     OperandKind firstArgKind = m_operands[0u].getInfo().kind;
+
+    if (firstArgKind != OperandKind::eSrcReg && firstArgKind != OperandKind::eDstReg)
+      return 0u;
+
+    uint32_t srcCount = uint32_t(m_operands.size());
+
     if (firstArgKind == OperandKind::eDstReg)
-      return uint32_t(m_operands.size() - 1u);
+      srcCount--;
 
-    if (firstArgKind == OperandKind::eSrcReg)
-      return uint32_t(m_operands.size());
-
-    return 0u;
+    return srcCount;
   }
 
   /** Retrieves number of immediate operands */

--- a/util/util_byte_stream.h
+++ b/util/util_byte_stream.h
@@ -47,6 +47,11 @@ public:
     return m_size - m_offset;
   }
 
+  /** Queries the current offset. */
+  size_t getOffset() const {
+    return m_offset;
+  }
+
   /* Sets read location to given fixed offset.
    * Returns true if the offset is in bounds. */
   ByteReader getRange(size_t offset, size_t size) const {


### PR DESCRIPTION
Turns clipping into a function.

The final code looks like this:

```glsl

layout(set = 0, binding = 1, std140) uniform ClipPlanes_buf
{
    vec4 m[6];
} ClipPlanes;

void clipping(vec4 position)
{
    uint _419 = ClipPlaneCount(0u, 32u);
    float _425 = (_419 > 0u) ? dp4_f32_legacy(position, ClipPlanes.m[0u]) : 0.0;
    gl_ClipDistance[0u] = _425;
    float _431 = (_419 > 1u) ? dp4_f32_legacy(position, ClipPlanes.m[1u]) : 0.0;
    gl_ClipDistance[1u] = _431;
    float _437 = (_419 > 2u) ? dp4_f32_legacy(position, ClipPlanes.m[2u]) : 0.0;
    gl_ClipDistance[2u] = _437;
    float _443 = (_419 > 3u) ? dp4_f32_legacy(position, ClipPlanes.m[3u]) : 0.0;
    gl_ClipDistance[3u] = _443;
    float _449 = (_419 > 4u) ? dp4_f32_legacy(position, ClipPlanes.m[4u]) : 0.0;
    gl_ClipDistance[4u] = _449;
    float _455 = (_419 > 5u) ? dp4_f32_legacy(position, ClipPlanes.m[5u]) : 0.0;
    gl_ClipDistance[5u] = _455;
}
```

Also fixes the clip plane count check. Right now it checks `i <= ClipPlaneCount` which is wrong.
The PR fixes this to `i < ClipPlaneCount`.

Then there's a function that returns the current parser cursor position. We'll need that to get the length of the shader bytecode in DXVK, for example to calculate the hash to identify the shader.