### PR TITLE
Properly handle unreachable blocks

### DIFF
--- a/ir/passes/ir_pass_cfg_cleanup.cpp
+++ b/ir/passes/ir_pass_cfg_cleanup.cpp
@@ -186,6 +186,36 @@ std::pair<bool, Builder::iterator> CleanupControlFlowPass::handleLabel(Builder::
   if (!isBlockUsed(op->getDef()))
     return std::make_pair(true, m_builder.iter(removeBlock(op->getDef())));
 
+  /* If the block is used but unreachable (which can be the case for merge blocks)
+   * and isn't already marked as unreachable, replace it with an unreachable block. */
+  if (!isBlockReachable(op->getDef()) && !isContinueBlock(op->getDef())) {
+    const auto& nextOp = m_builder.getOp(m_builder.getNext(op->getDef()));
+
+    if (nextOp.getOpCode() == OpCode::eUnreachable)
+      return std::make_pair(false, ++op);
+
+    auto block = m_builder.addBefore(op->getDef(), Op::Label());
+    m_builder.addBefore(op->getDef(), Op::Unreachable());
+
+    auto [a, b] = m_builder.getUses(op->getDef());
+
+    for (auto iter = a; iter != b; iter++) {
+      if (iter->getOpCode() == OpCode::eLabel) {
+        Op labelOp = *iter;
+
+        for (uint32_t i = 0u; i < labelOp.getFirstLiteralOperandIndex(); i++) {
+          if (SsaDef(labelOp.getOperand(i)) == op->getDef())
+            labelOp.setOperand(i, block);
+        }
+
+        m_builder.rewriteOp(iter->getDef(), labelOp);
+      }
+    }
+
+    dxbc_spv_assert(!isBlockUsed(op->getDef()));
+    return std::make_pair(true, m_builder.iter(removeBlock(op->getDef())));
+  }
+
   /* If the block does not serve any special function w.r.t. structured control flow,
    * only has a single predecessor, and if that predecessor is not the header of any
    * construct and unconditionally branches to this block without any trivial phi,

--- a/ir/passes/ir_pass_cfg_convert.cpp
+++ b/ir/passes/ir_pass_cfg_convert.cpp
@@ -112,6 +112,9 @@ Builder::iterator ConvertControlFlowPass::handleFunction(Builder::iterator op) {
    * to the list of labels to check for removal since it is never directly referenced
    * by any instruction. */
   dxbc_spv_assert(!m_currBlock);
+  dxbc_spv_assert(!m_currFunction);
+
+  m_currFunction = op->getDef();
 
   auto block = m_builder.addAfter(op->getDef(), Op::Label());
   return m_builder.iter(block);
@@ -120,9 +123,17 @@ Builder::iterator ConvertControlFlowPass::handleFunction(Builder::iterator op) {
 
 Builder::iterator ConvertControlFlowPass::handleFunctionEnd(Builder::iterator op) {
   /* Add return instruction to terminate the current block, if any. */
-  m_builder.addBefore(op->getDef(), Op::Return());
+  ir::Type returnType = m_builder.getOp(m_currFunction).getType();
+
+  if (!returnType.isVoidType()) {
+    m_builder.addBefore(op->getDef(), Op::Return(returnType,
+      m_builder.makeUndef(returnType)));
+  } else {
+    m_builder.addBefore(op->getDef(), Op::Return());
+  }
 
   m_currBlock = ir::SsaDef();
+  m_currFunction = ir::SsaDef();
   return ++op;
 }
 

--- a/ir/passes/ir_pass_cfg_convert.h
+++ b/ir/passes/ir_pass_cfg_convert.h
@@ -61,6 +61,7 @@ private:
   Builder& m_builder;
 
   /* Active label, if any. */
+  SsaDef m_currFunction = { };
   SsaDef m_currBlock = { };
 
   /* Nested control flow constructs, with the innermost block last. */


### PR DESCRIPTION
Part 1 ensures that the default return actually uses the correct return type (this was leading to invalid spirv and subsequent driver crashes with dynamically indexed inputs in SM3), and Part 2 *actually* marks unreachable blocks as unreachable.