### PR TITLE
Handle SM3 patterns.

### DIFF
--- a/dxbc/dxbc_converter.cpp
+++ b/dxbc/dxbc_converter.cpp
@@ -697,8 +697,10 @@ bool Converter::handleCustomData(ir::Builder& builder, const Instruction& op) {
 bool Converter::handleDclGlobalFlags(ir::Builder& builder, const Instruction& op) {
   auto flags = op.getOpToken().getGlobalFlags();
 
-  if (flags & GlobalFlag::eRefactoringAllowed)
+  if (flags & GlobalFlag::eRefactoringAllowed) {
     m_fpMode.defaultFlags -= ir::OpFlag::ePrecise;
+    m_fpMode.defaultFlags |= ir::OpFlag::eNoSz;
+  }
 
   if (flags & (GlobalFlag::eEnableFp64 | GlobalFlag::eEnableExtFp64))
     m_fpMode.hasFp64 = true;

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2198,6 +2198,18 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
             isConstantNegative = isConstantNegative || (uint64_t(posOperand) & signBit);
             isConstantPositive = isConstantPositive || !(uint64_t(posOperand) & signBit);
 
+            /* Eliminate addition with signed zero. If we don't care about
+             * signed zeroes anyway, eliminage any addition with zero. */
+            auto zeroCandidate = uint64_t(isSub ? posOperand : negOperand);
+
+            if (getFpFlags(*op) & OpFlag::eNoSz)
+              zeroCandidate &= ~signBit;
+
+            if (!zeroCandidate) {
+              isConstantPositive = false;
+              isConstantNegative = false;
+            }
+
             constant.addOperand(negOperand);
           }
         }

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2162,8 +2162,8 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
       }
     } [[fallthrough]];
 
-    case OpCode::eFAdd:
-    case OpCode::eFSub: {
+    case OpCode::eFSub:
+    case OpCode::eFAdd: {
       bool isInt = op->getOpCode() == OpCode::eIAdd || op->getOpCode() == OpCode::eISub;
       bool isSub = op->getOpCode() == OpCode::eISub || op->getOpCode() == OpCode::eFSub;
 
@@ -2294,6 +2294,25 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
             baseOp.getDef(), RoundMode::ePositiveInf).setFlags(op->getFlags()));
           return std::make_pair(true, op);
         }
+      }
+
+      /* a - fract(a) -> floor(a)
+       * fract(a) - a -> -floor(a) */
+      if (isSub && !preserveNanSz &&
+          ((a.getOpCode() == OpCode::eFFract && SsaDef(a.getOperand(0u)) == b.getDef()) ||
+           (b.getOpCode() == OpCode::eFFract && SsaDef(b.getOperand(0u)) == a.getDef()))) {
+        bool negate = a.getOpCode() == OpCode::eFFract;
+
+        auto base = negate ? b.getDef() : a.getDef();
+        auto newOp = Op::FRound(op->getType(), base, RoundMode::eNegativeInf).setFlags(op->getFlags());
+
+        if (negate) {
+          auto newDef = m_builder.addBefore(op->getDef(), std::move(newOp));
+          newOp = Op::FNeg(op->getType(), newDef).setFlags(op->getFlags());
+        }
+
+        m_builder.rewriteOp(op->getDef(), std::move(newOp));
+        return std::make_pair(true, op);
       }
     } break;
 

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -3510,6 +3510,8 @@ std::pair<bool, Builder::iterator> ArithmeticPass::reorderConstantOperandsOp(Bui
     case OpCode::eFMadLegacy:
     case OpCode::eFMin:
     case OpCode::eFMax:
+    case OpCode::eFDot:
+    case OpCode::eFDotLegacy:
     case OpCode::eIAnd:
     case OpCode::eIOr:
     case OpCode::eIXor:

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1852,9 +1852,11 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
       }
     } break;
 
-    case OpCode::eFMulLegacy: {
+    case OpCode::eFMulLegacy:
+    case OpCode::eFMadLegacy: {
       const auto& a = m_builder.getOpForOperand(*op, 0u);
       const auto& b = m_builder.getOpForOperand(*op, 1u);
+      auto c = SsaDef(op->getOperand(2u));
 
       bool replaceFmul = false;
 
@@ -1871,33 +1873,48 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
         replaceFmul = true;
 
       if (replaceFmul) {
-        m_builder.rewriteOp(op->getDef(),
-          Op::FMul(op->getType(), a.getDef(), b.getDef()).setFlags(op->getFlags()));
+        m_builder.rewriteOp(op->getDef(), c
+          ? Op::FMad(op->getType(), a.getDef(), b.getDef(), c).setFlags(op->getFlags())
+          : Op::FMul(op->getType(), a.getDef(), b.getDef()).setFlags(op->getFlags()));
         return std::make_pair(true, op);
       }
     } [[fallthrough]];
 
-    case OpCode::eFMul: {
+    case OpCode::eFMul:
+    case OpCode::eFMad: {
       const auto& a = m_builder.getOpForOperand(*op, 0u);
       const auto& b = m_builder.getOpForOperand(*op, 1u);
+      auto c = SsaDef(op->getOperand(2u));
 
       if (!(getFpFlags(*op) & OpFlag::ePrecise) && b.isConstant() &&
           op->getType().getBaseType(0u).isScalar()) {
-        /* a * 0 -> 0 */
+        /* a * 0 -> 0
+         * a * 0 + c -> c */
         if (getConstantAsFloat(b, 0u) == 0.0) {
-          auto next = m_builder.rewriteDef(op->getDef(), m_builder.makeConstantZero(op->getType()));
+          auto next = m_builder.rewriteDef(op->getDef(),
+            c ? c : m_builder.makeConstantZero(op->getType()));
           return std::make_pair(true, m_builder.iter(next));
         }
 
-        /* a * 1 -> a */
+        /* a * 1 -> a
+         * a * 1 + c -> a + c */
         if (getConstantAsFloat(b, 0u) == 1.0) {
-          auto next = m_builder.rewriteDef(op->getDef(), a.getDef());
-          return std::make_pair(true, m_builder.iter(next));
+          if (c) {
+            m_builder.rewriteOp(op->getDef(), Op::FAdd(
+              op->getType(), a.getDef(), c).setFlags(op->getFlags()));
+            return std::make_pair(true, op);
+          } else {
+            auto next = m_builder.rewriteDef(op->getDef(), a.getDef());
+            return std::make_pair(true, m_builder.iter(next));
+          }
         }
 
-        /* a * -1 -> -a */
+        /* a * -1 -> -a
+         * a * -1 + c -> c - a */
         if (getConstantAsFloat(b, 0u) == -1.0) {
-          m_builder.rewriteOp(op->getDef(), Op::FNeg(op->getType(), a.getDef()).setFlags(a.getFlags()));
+          m_builder.rewriteOp(op->getDef(), c
+            ? Op::FSub(op->getType(), c, a.getDef()).setFlags(op->getFlags())
+            : Op::FNeg(op->getType(), a.getDef()).setFlags(a.getFlags()));
           return std::make_pair(true, op);
         }
       }
@@ -2970,6 +2987,8 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityOp(Builder::it
     case OpCode::eFSub:
     case OpCode::eFMul:
     case OpCode::eFMulLegacy:
+    case OpCode::eFMad:
+    case OpCode::eFMadLegacy:
     case OpCode::eFDotLegacy:
     case OpCode::eFDiv:
     case OpCode::eFMin:

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1594,9 +1594,18 @@ std::pair<bool, Builder::iterator> ArithmeticPass::selectFMul(Builder::iterator 
   auto cond = m_builder.getOpForOperand(select, 0u).getDef();
   auto a = m_builder.getOpForOperand(select, 1u).getDef();
   auto b = m_builder.getOpForOperand(select, 2u).getDef();
+  auto c = SsaDef(op->getOperand(2u));
 
-  a = m_builder.addBefore(op->getDef(), Op(op->getOpCode(), op->getType()).addOperands(value.getDef(), a).setFlags(op->getFlags()));
-  b = m_builder.addBefore(op->getDef(), Op(op->getOpCode(), op->getType()).addOperands(value.getDef(), b).setFlags(op->getFlags()));
+  auto aOp = Op(op->getOpCode(), op->getType()).addOperands(value.getDef(), a).setFlags(op->getFlags());
+  auto bOp = Op(op->getOpCode(), op->getType()).addOperands(value.getDef(), b).setFlags(op->getFlags());
+
+  if (c) {
+    aOp.addOperand(c);
+    bOp.addOperand(c);
+  }
+
+  a = m_builder.addBefore(op->getDef(), aOp);
+  b = m_builder.addBefore(op->getDef(), bOp);
 
   m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), cond, a, b).setFlags(op->getFlags()));
   return std::make_pair(true, op);
@@ -1679,6 +1688,8 @@ std::pair<bool, Builder::iterator> ArithmeticPass::selectOp(Builder::iterator op
 
     case OpCode::eFMul:
     case OpCode::eFMulLegacy:
+    case OpCode::eFMad:
+    case OpCode::eFMadLegacy:
       return selectFMul(op);
 
     case OpCode::eFAdd:

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1933,6 +1933,19 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
       }
     } break;
 
+    case OpCode::eFDotLegacy: {
+      const auto& a = m_builder.getOpForOperand(*op, 0u);
+      const auto& b = m_builder.getOpForOperand(*op, 1u);
+
+      /* Replace with non-legacy dot if operands are the same
+       * since we're just squaring numbers at that point */
+      if (a.getDef() == b.getDef()) {
+        m_builder.rewriteOp(op->getDef(),
+          Op::FDot(op->getType(), a.getDef(), b.getDef()).setFlags(op->getFlags()));
+        return std::make_pair(true, op);
+      }
+    } break;
+
     case OpCode::eUMin: {
       const auto& a = m_builder.getOpForOperand(*op, 0u);
       const auto& b = m_builder.getOpForOperand(*op, 1u);
@@ -2957,6 +2970,7 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityOp(Builder::it
     case OpCode::eFSub:
     case OpCode::eFMul:
     case OpCode::eFMulLegacy:
+    case OpCode::eFDotLegacy:
     case OpCode::eFDiv:
     case OpCode::eFMin:
     case OpCode::eFMax:

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1833,6 +1833,22 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
           auto next = m_builder.rewriteDef(op->getDef(), SsaDef(a.getOperand(0u)));
           return std::make_pair(true, m_builder.iter(next));
         }
+
+        if (isOnlyUse(m_builder, a.getDef(), op->getDef()) || (op->getFlags() & OpFlag::eInvariant)) {
+          /* rcp(rsq(a)) -> sqrt(a) */
+          if (a.getOpCode() == OpCode::eFRsq) {
+            m_builder.rewriteOp(op->getDef(), Op::FSqrt(
+              op->getType(), SsaDef(a.getOperand(0u))).setFlags(op->getFlags()));
+            return std::make_pair(true, op);
+          }
+
+          /* rcp(sqrt(a)) -> rsq(a) */
+          if (a.getOpCode() == OpCode::eFSqrt) {
+            m_builder.rewriteOp(op->getDef(), Op::FRsq(
+              op->getType(), SsaDef(a.getOperand(0u))).setFlags(op->getFlags()));
+            return std::make_pair(true, op);
+          }
+        }
       }
     } break;
 

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2714,6 +2714,16 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityCompareOp(Buil
     }
   }
 
+  /* op(-a, const) -> op(-const, a) */
+  if (a.getOpCode() == OpCode::eFNeg && b.isConstant()) {
+    auto newConst = m_builder.addBefore(op->getDef(), Op::FNeg(b.getType(), b.getDef()));
+    auto newValue = m_builder.getOpForOperand(a, 0u).getDef();
+
+    m_builder.rewriteOp(op->getDef(), Op(op->getOpCode(), op->getType())
+      .addOperands(newConst, newValue).setFlags(op->getFlags()));
+    return std::make_pair(true, op);
+  }
+
   /* For comparisons, we can only really do anything
    * if the operands are the same */
   if (a.getDef() != b.getDef())

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1792,7 +1792,17 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveCastOp(Builder::iterat
 
 std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(Builder::iterator op) {
   switch (op->getOpCode()) {
-    case OpCode::eFAbs:
+    case OpCode::eFAbs: {
+      /* |a*a| -> a*a */
+      const auto& a = m_builder.getOpForOperand(*op, 0u);
+
+      if ((a.getOpCode() == OpCode::eFMul || a.getOpCode() == OpCode::eFDot) &&
+          SsaDef(a.getOperand(0u)) == SsaDef(a.getOperand(1u))) {
+        auto next = m_builder.rewriteDef(op->getDef(), a.getDef());
+        return std::make_pair(true, m_builder.iter(next));
+      }
+    } [[fallthrough]];
+
     case OpCode::eIAbs: {
       /* |(|a|)| -> |a|
        * |-a| -> |a| */

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1616,35 +1616,61 @@ std::pair<bool, Builder::iterator> ArithmeticPass::selectFAdd(Builder::iterator 
   if (getFpFlags(*op) & OpFlag::ePrecise)
     return std::make_pair(false, ++op);
 
-  /* If we can statically prove that c0 and c1 are mutually exclusive:
-   * select(c0, a, 0) + select(c1, b, c) -> select(c0, a, select(c1, b, c))
-   * select(c0, a, b) + select(c1, c, 0) -> select(c1, c, select(c0, a, b))
-   * Note that this optimization may eliminate a denorm flush. */
-  const auto& selectA = m_builder.getOpForOperand(*op, 0u);
-  const auto& selectB = m_builder.getOpForOperand(*op, 1u);
+  const auto& a = m_builder.getOpForOperand(*op, 0u);
+  const auto& b = m_builder.getOpForOperand(*op, 1u);
 
-  if (selectA.getOpCode() != OpCode::eSelect || selectB.getOpCode() != OpCode::eSelect)
-    return std::make_pair(false, ++op);
+  /* select(c0, a, 0) + b -> select(c0, a + b, b)
+   * select(c0, 0, a) + b -> select(c0, b, a + b) */
+  bool aIsSelect = a.getOpCode() == OpCode::eSelect;
+  bool bIsSelect = b.getOpCode() == OpCode::eSelect;
 
-  const auto& ac = m_builder.getOpForOperand(selectA, 0u);
-  const auto& at = m_builder.getOpForOperand(selectA, 1u);
-  const auto& af = m_builder.getOpForOperand(selectA, 2u);
+  if (aIsSelect && bIsSelect) {
+    /* If we can statically prove that c0 and c1 are mutually exclusive:
+     * select(c0, a, 0) + select(c1, b, c) -> select(c0, a, select(c1, b, c))
+     * select(c0, a, b) + select(c1, c, 0) -> select(c1, c, select(c0, a, b))
+     * Note that this optimization may eliminate a denorm flush. */
+    const auto& ac = m_builder.getOpForOperand(a, 0u);
+    const auto& at = m_builder.getOpForOperand(a, 1u);
+    const auto& af = m_builder.getOpForOperand(a, 2u);
 
-  const auto& bc = m_builder.getOpForOperand(selectB, 0u);
-  const auto& bt = m_builder.getOpForOperand(selectB, 1u);
-  const auto& bf = m_builder.getOpForOperand(selectB, 2u);
+    const auto& bc = m_builder.getOpForOperand(b, 0u);
+    const auto& bt = m_builder.getOpForOperand(b, 1u);
+    const auto& bf = m_builder.getOpForOperand(b, 2u);
 
-  if (evalBAnd(ac, bc) != std::make_optional(false))
-    return std::make_pair(false, ++op);
+    if (evalBAnd(ac, bc) != std::make_optional(false))
+      return std::make_pair(false, ++op);
 
-  if (isConstantValue(bf, 0)) {
-    m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), bc.getDef(), bt.getDef(), selectA.getDef()).setFlags(op->getFlags()));
-    return std::make_pair(true, op);
-  }
+    if (isConstantValue(bf, 0)) {
+      m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), bc.getDef(), bt.getDef(), a.getDef()).setFlags(op->getFlags()));
+      return std::make_pair(true, op);
+    }
 
-  if (isConstantValue(af, 0)) {
-    m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), ac.getDef(), at.getDef(), selectB.getDef()).setFlags(op->getFlags()));
-    return std::make_pair(true, op);
+    if (isConstantValue(af, 0)) {
+      m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), ac.getDef(), at.getDef(), b.getDef()).setFlags(op->getFlags()));
+      return std::make_pair(true, op);
+    }
+  } else if ((aIsSelect || bIsSelect) && (getFpFlags(*op) & OpFlag::eNoSz)) {
+    /* select(a, b, 0) + c -> select(a, b + c, c)
+     * select(a, 0, b) + c -> select(a, c, b + c) */
+    const auto& selectOp = aIsSelect ? a : b;
+    const auto& valueOp = aIsSelect ? b : a;
+
+    if (isOnlyUse(m_builder, selectOp.getDef(), op->getDef()) || (getFpFlags(*op) & OpFlag::eInvariant)) {
+      const auto& sc = m_builder.getOpForOperand(selectOp, 0u);
+      const auto& st = m_builder.getOpForOperand(selectOp, 1u);
+      const auto& sf = m_builder.getOpForOperand(selectOp, 2u);
+
+      /* Add with constant 0 will be optimized away separately */
+      bool stIsZero = isConstantValue(st, 0);
+      bool sfIsZero = isConstantValue(sf, 0);
+
+      if (stIsZero || sfIsZero) {
+        m_builder.rewriteOp(op->getDef(), Op::Select(op->getType(), sc.getDef(),
+          m_builder.addBefore(op->getDef(), Op::FAdd(op->getType(), st.getDef(), valueOp.getDef())),
+          m_builder.addBefore(op->getDef(), Op::FAdd(op->getType(), sf.getDef(), valueOp.getDef()))).setFlags(op->getFlags()));
+        return std::make_pair(true, op);
+      }
+    }
   }
 
   return std::make_pair(false, ++op);

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -4418,6 +4418,9 @@ OpFlags ArithmeticPass::getFpFlags(const Op& op) const {
   auto type = op.getType().getBaseType(0u).getBaseType();
   auto flags = op.getFlags();
 
+  if (flags & OpFlag::ePrecise)
+    return flags;
+
   switch (type) {
     case ScalarType::eF16: return flags | m_fp16Flags;
     case ScalarType::eF32: return flags | m_fp32Flags;

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2940,6 +2940,69 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentitySelect(Builder
     }
   }
 
+  /* select(fract(x) <= 0 || x >= 0, floor(a), floor(a) + 1) -> trunc(x)
+   * select(fract(x) > 0 && x < 0, floor(a) + 1, floor(a)) -> trunc(x)
+   * Handle this pattern last due to complexity. */
+  if (a.getOpCode() == OpCode::eFRound || b.getOpCode() == OpCode::eFRound) {
+    const auto& floorOp = a.getOpCode() == OpCode::eFRound ? a : b;
+    const auto& addOp = a.getOpCode() == OpCode::eFRound ? b : a;
+
+    /* Verify that the round op is actually floor() */
+    if (RoundMode(floorOp.getOperand(1u)) != RoundMode::eNegativeInf ||
+        (getFpFlags(floorOp) & OpFlag::ePrecise))
+      return std::make_pair(false, ++op);
+
+    /* Ensure that the addition is floor(x) + 1 */
+    if (addOp.getOpCode() != OpCode::eFAdd || (getFpFlags(addOp) & OpFlag::ePrecise))
+      return std::make_pair(false, ++op);
+
+    const auto& addA = m_builder.getOpForOperand(addOp, 0u);
+    const auto& addB = m_builder.getOpForOperand(addOp, 1u);
+
+    if (addA.getDef() != floorOp.getDef() || !addB.isConstant() || getConstantAsFloat(addB, 0u) != 1.0f)
+      return std::make_pair(false, ++op);
+
+    /* Make sure the floor op is on the correct side of the select */
+    if ((cond.getOpCode() != OpCode::eBAnd || b.getDef() != floorOp.getDef()) &&
+        (cond.getOpCode() != OpCode::eBOr  || a.getDef() != floorOp.getDef()))
+      return std::make_pair(false, ++op);
+
+    /* Depending on the pattern used, check for the fract compare and raw compare.
+     * We can ignore nan behaviour because the addition would return nan anyway */
+    const auto& valueOp = m_builder.getOpForOperand(floorOp, 0u);
+
+    auto fractCompare = cond.getOpCode() == OpCode::eBOr ? OpCode::eFLe : OpCode::eFGt;
+    auto valueCompare = cond.getOpCode() == OpCode::eBOr ? OpCode::eFGe : OpCode::eFLt;
+
+    for (uint32_t i = 0u; i < cond.getOperandCount(); i++) {
+      const auto& cmpOp = m_builder.getOpForOperand(cond, 0u);
+
+      if (cmpOp.getOpCode() != fractCompare && cmpOp.getOpCode() != valueCompare)
+        return std::make_pair(false, ++op);
+
+      /* Second operand must be constant 0 no matter what */
+      const auto& cmpA = m_builder.getOpForOperand(cmpOp, 0u);
+      const auto& cmpB = m_builder.getOpForOperand(cmpOp, 1u);
+
+      if (!cmpB.isConstant() || std::fpclassify(getConstantAsFloat(cmpB, 0u)) != FP_ZERO)
+        return std::make_pair(false, ++op);
+
+      if (cmpOp.getOpCode() == fractCompare) {
+        if (cmpA.getOpCode() != OpCode::eFFract || m_builder.getOpForOperand(cmpA, 0u).getDef() != valueOp.getDef())
+          return std::make_pair(false, ++op);
+      }
+
+      if (cmpOp.getOpCode() == valueCompare) {
+        if (cmpA.getDef() != valueOp.getDef())
+          return std::make_pair(false, ++op);
+      }
+    }
+
+    m_builder.rewriteOp(op->getDef(), Op::FRound(op->getType(),
+      valueOp.getDef(), RoundMode::eZero).setFlags(op->getFlags()));
+    return std::make_pair(true, op);
+  }
+
   return std::make_pair(false, ++op);
 }
 

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1856,18 +1856,24 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
       const auto& a = m_builder.getOpForOperand(*op, 0u);
       const auto& b = m_builder.getOpForOperand(*op, 1u);
 
+      bool replaceFmul = false;
+
       if (b.isConstant()) {
-        bool replaceFmul = true;
+        replaceFmul = true;
 
         for (uint32_t i = 0u; i < b.getOperandCount(); i++) {
           auto fpClass = std::fpclassify(getConstantAsFloat(b, i));
           replaceFmul = replaceFmul && fpClass == FP_NORMAL;
         }
+      }
 
-        if (replaceFmul) {
-          m_builder.rewriteOp(op->getDef(), Op::FMul(op->getType(), a.getDef(), b.getDef()));
-          return std::make_pair(true, op);
-        }
+      if (a.getDef() == b.getDef())
+        replaceFmul = true;
+
+      if (replaceFmul) {
+        m_builder.rewriteOp(op->getDef(),
+          Op::FMul(op->getType(), a.getDef(), b.getDef()).setFlags(op->getFlags()));
+        return std::make_pair(true, op);
       }
     } [[fallthrough]];
 

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2541,6 +2541,37 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityCompareOp(Buil
     }
   }
 
+  /* op(a, -a) = op(a, 0)
+   * op(-a, a) = op(0, a)
+   * op(-a, -b) = op(b, a)
+   * Only works for floats since -INT_MIN == INT_MIN. */
+  if (a.getOpCode() == OpCode::eFNeg || b.getOpCode() == OpCode::eFNeg) {
+    bool aIsNeg = a.getOpCode() == OpCode::eFNeg;
+    bool bIsNeg = b.getOpCode() == OpCode::eFNeg;
+
+    auto aDef = aIsNeg ? SsaDef(a.getOperand(0u)) : a.getDef();
+    auto bDef = bIsNeg ? SsaDef(b.getOperand(0u)) : b.getDef();
+
+    if (aIsNeg && bIsNeg) {
+      m_builder.rewriteOp(op->getDef(), Op(op->getOpCode(), op->getType())
+        .setFlags(op->getFlags())
+        .addOperand(bDef)
+        .addOperand(aDef));
+      return std::make_pair(true, op);
+    }
+
+    /* Exactly one operand is negative */
+    if (aDef == bDef) {
+      auto zero = m_builder.add(Op(OpCode::eConstant, a.getType()).addOperand(Operand()));
+
+      m_builder.rewriteOp(op->getDef(), Op(op->getOpCode(), op->getType())
+        .setFlags(op->getFlags())
+        .addOperand(aIsNeg ? zero : aDef)
+        .addOperand(aIsNeg ? aDef : zero));
+      return std::make_pair(true, op);
+    }
+  }
+
   /* For comparisons, we can only really do anything
    * if the operands are the same */
   if (a.getDef() != b.getDef())

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -2277,6 +2277,24 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
           return std::make_pair(true, m_builder.iter(next));
         }
       }
+
+      /* a + fract(-a) -> ceil(a) */
+      bool preserveNanSz = ((getFpFlags(*op) | getFpFlags(a) | getFpFlags(b)) & OpFlag::ePrecise) &&
+        (!((getFpFlags(a) & getFpFlags(b)) & OpFlag::eNoInf) || !(getFpFlags(*op) & OpFlag::eNoSz));
+
+      if (!isSub && !preserveNanSz && (a.getOpCode() == OpCode::eFFract || b.getOpCode() == OpCode::eFFract)) {
+        const auto& fractOp = m_builder.getOpForOperand(a.getOpCode() == OpCode::eFFract ? a : b, 0u);
+        const auto& baseOp = a.getOpCode() == OpCode::eFFract ? b : a;
+
+        bool isCeil = fractOp.getOpCode() == OpCode::eFNeg &&
+          m_builder.getOpForOperand(fractOp, 0u).getDef() == baseOp.getDef();
+
+        if (isCeil) {
+          m_builder.rewriteOp(op->getDef(), Op::FRound(op->getType(),
+            baseOp.getDef(), RoundMode::ePositiveInf).setFlags(op->getFlags()));
+          return std::make_pair(true, op);
+        }
+      }
     } break;
 
     case OpCode::eINot: {

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1243,6 +1243,14 @@ std::pair<bool, Builder::iterator> ArithmeticPass::selectCompare(Builder::iterat
   auto tDef = SsaDef(a.getOperand(1u));
   auto fDef = SsaDef(a.getOperand(2u));
 
+  /* Be a bit more conservative around floats and only allow checking for constant
+   * operands that we can easily eliminate. Resolves some SM3 comparison patterns. */
+  if (b.getType().getBaseType(0u).isFloatType() && (
+      !m_builder.getOp(tDef).isConstant() ||
+      !m_builder.getOp(fDef).isConstant() ||
+      !b.isConstant()))
+    return std::make_pair(false, ++op);
+
   tDef = m_builder.addBefore(op->getDef(), Op(op->getOpCode(), op->getType()).addOperands(tDef, b.getDef()));
   fDef = m_builder.addBefore(op->getDef(), Op(op->getOpCode(), op->getType()).addOperands(fDef, b.getDef()));
 
@@ -1658,6 +1666,8 @@ std::pair<bool, Builder::iterator> ArithmeticPass::selectOp(Builder::iterator op
 
     case OpCode::eIEq:
     case OpCode::eINe:
+    case OpCode::eFEq:
+    case OpCode::eFNe:
       return selectCompare(op);
 
     case OpCode::ePhi:

--- a/ir/passes/ir_pass_arithmetic.cpp
+++ b/ir/passes/ir_pass_arithmetic.cpp
@@ -1939,6 +1939,27 @@ std::pair<bool, Builder::iterator> ArithmeticPass::resolveIdentityArithmeticOp(B
           return std::make_pair(true, op);
         }
       }
+
+      /* mad(a, b, 0) -> a * b */
+      if (c && !(getFpFlags(*op) & OpFlag::ePrecise) && (getFpFlags(*op) & OpFlag::eNoSz)) {
+        const auto& cOp = m_builder.getOp(c);
+        bool optimize = cOp.isConstant();
+
+        for (uint32_t i = 0u; i < cOp.getOperandCount() && optimize; i++)
+          optimize = std::fpclassify(getConstantAsFloat(cOp, i)) == FP_ZERO;
+
+        if (optimize) {
+          auto opCode = op->getOpCode() == OpCode::eFMadLegacy
+            ? OpCode::eFMulLegacy
+            : OpCode::eFMul;
+
+          m_builder.rewriteOp(op->getDef(), Op(opCode, op->getType())
+            .addOperand(a.getDef())
+            .addOperand(b.getDef())
+            .setFlags(op->getFlags()));
+          return std::make_pair(true, op);
+        }
+      }
     } break;
 
     case OpCode::eFDiv: {

--- a/spirv/spirv_builder.cpp
+++ b/spirv/spirv_builder.cpp
@@ -2858,8 +2858,11 @@ void SpirvBuilder::emitFpMode(const ir::Op& op, uint32_t id, uint32_t mask) {
   if (m_options.floatControls2) {
     /* Fp mode flags in our IR are additive, only emit a decoration if
      * the instruction sets any flags not included in the default. */
+    if (!(desiredMode & ir::OpFlag::ePrecise))
+      desiredMode |= defaultMode;
+
     auto defaultFlags = getFpModeFlags(defaultMode);
-    auto desiredFlags = getFpModeFlags(defaultMode | desiredMode) | mask;
+    auto desiredFlags = getFpModeFlags(desiredMode) | mask;
 
     if (desiredFlags != defaultFlags) {
       enableCapability(spv::CapabilityFloatControls2);


### PR DESCRIPTION
Cleans up a lot of SM3 jank, especially around rounding functions, square roots and boolean logic.

Also fixes an issue were FMad didn't participate in some transforms meant for FMul. This is relevant because we moved the fuse mad pass *before* all the other transforms passes at some point in order to avoid breaking invariance by accident.

This *doesn't* clean up comparisons like `a - b > 0`, however. Not sure what to do here, even if we ignore inf->nan edge cases, optimizing that doesn't seem super safe for SM5 content due to rounding errors.

Should probably test a bunch to make sure that this doesn't regress anything, including D3D11.