### PR TITLE
Shader Model 1-3: Some more tiny fixes

### DIFF
--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -246,6 +246,7 @@ std::optional<ir::BuiltIn> IoMap::determineBuiltinForRegister(RegisterType regTy
       }
 
       if (regIndex == uint32_t(MiscTypeIndex::eMiscTypePosition)) {
+        dxbc_spv_assert(semantic.usage == SemanticUsage::ePosition && semantic.index == 0u);
         return std::make_optional(ir::BuiltIn::ePosition);
       }
 

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -234,9 +234,10 @@ std::optional<ir::BuiltIn> IoMap::determineBuiltinForRegister(RegisterType regTy
 
   } else {
 
-    /* Position must not be mapped to a regular input. SM3 still has a separate register for that. */
+    /* Position 0 must not be mapped to a regular input. SM3 still has a separate register for that. */
     dxbc_spv_assert(shaderInfo.getType() == ShaderType::eVertex
       || semantic.usage != SemanticUsage::ePosition
+      || semantic.index != 0u
       || regType != RegisterType::eInput);
 
     if (regType == RegisterType::eMiscType) {

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -615,7 +615,7 @@ ir::SsaDef IoMap::emitLoad(
             value = builder.add(ir::Op::FSub(varScalarType, value, builder.makeConstant(0.5f)));
 
           if (m_converter.getShaderInfo().getType() == ShaderType::ePixel
-            && ioVar->registerType == RegisterType::eInput
+            && (ioVar->registerType == RegisterType::eInput || ioVar->registerType == RegisterType::ePixelTexCoord)
             && ioVar->semantic.usage == SemanticUsage::eTexCoord) {
             /* We need to replace TEXCOORD inputs with gl_PointCoord
              * if D3DRS_POINTSPRITEENABLE is set. */

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -696,7 +696,7 @@ ir::SsaDef IoMap::emitTexCoordLoad(
 }
 
 
-ir::SsaDef IoMap::emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoordComponent, uint32_t componentIndex) {
+ir::SsaDef IoMap::emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoordComponent, uint32_t componentIndex) const {
   if (m_converter.getShaderInfo().getType() != ShaderType::ePixel
     || (ioVar.registerType != RegisterType::eInput && ioVar.registerType != RegisterType::ePixelTexCoord)
     || ioVar.semantic.usage != SemanticUsage::eTexCoord)
@@ -1030,7 +1030,8 @@ ir::SsaDef IoMap::emitDynamicLoadFunction(ir::Builder& builder) const {
 
       for (uint32_t j = 0u; j < 4u; j++) {
         if ((baseType.isScalar() && j == 0) || j < baseType.getVectorSize()) {
-          components[j] = builder.add(ir::Op::CompositeExtract(ir::ScalarType::eF32, input, builder.makeConstant(i)));;
+          auto value = builder.add(ir::Op::CompositeExtract(ir::ScalarType::eF32, input, builder.makeConstant(i)));
+          components[j] = emitTexCoordPointSpriteAdjustment(builder, *ioVar, value, i);
         } else {
           components[j] = builder.makeConstant(0.0f);
         }

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -425,14 +425,6 @@ void IoMap::dclPointCoord(ir::Builder& builder) {
 }
 
 
-ir::SsaDef IoMap::emitPointCoordLoad(ir::Builder& builder, uint32_t componentIndex) {
-  if (componentIndex < 2) // The point coord input is only a vec2
-    return builder.add(ir::Op::InputLoad(ir::ScalarType::eF32, m_pointCoord, builder.makeConstant(componentIndex)));
-  else
-    return builder.makeConstant(0.0f);
-}
-
-
 void IoMap::emitIoVarDefaults(ir::Builder& builder) {
   for (const IoVarInfo& ioVar : m_variables) {
     emitIoVarDefault(builder, ioVar);
@@ -614,24 +606,7 @@ ir::SsaDef IoMap::emitLoad(
            && componentIndex < 2u)
             value = builder.add(ir::Op::FSub(varScalarType, value, builder.makeConstant(0.5f)));
 
-          if (m_converter.getShaderInfo().getType() == ShaderType::ePixel
-            && (ioVar->registerType == RegisterType::eInput || ioVar->registerType == RegisterType::ePixelTexCoord)
-            && ioVar->semantic.usage == SemanticUsage::eTexCoord) {
-            /* We need to replace TEXCOORD inputs with gl_PointCoord
-             * if D3DRS_POINTSPRITEENABLE is set. */
-            auto pointCoord = emitPointCoordLoad(builder, componentIndex);
-
-            auto specConstBit = m_converter.m_specConstants.get(builder, SpecConstantId::eSpecPointMode,
-              builder.makeConstant(1u), builder.makeConstant(1u));
-            auto pointSpriteEnabled = builder.add(ir::Op::IEq(ir::ScalarType::eBool, specConstBit, builder.makeConstant(1u)));
-
-            value = builder.add(ir::Op::Select(
-              varScalarType,
-              pointSpriteEnabled,
-              pointCoord,
-              value
-            ));
-          }
+          value = emitTexCoordPointSpriteAdjustment(builder, *ioVar, value, componentIndex);
 
         } else {
           /* The input register is writable. (SM 1 Texture register) */
@@ -712,10 +687,43 @@ ir::SsaDef IoMap::emitTexCoordLoad(
     ir::SsaDef addressConstant = builder.makeConstant(componentIndex);
     auto value = builder.add(ir::Op::InputLoad(varScalarType, ioVar->baseDef, addressConstant));
 
+    value = emitTexCoordPointSpriteAdjustment(builder, *ioVar, value, componentIndex);
+
     components[componentIndex] = convertScalar(builder, type, value);
   }
 
   return composite(builder, ir::BasicType(type, util::popcnt(uint8_t(componentMask))), components.data(), swizzle, componentMask);
+}
+
+
+ir::SsaDef IoMap::emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoordComponent, uint32_t componentIndex) {
+  if (m_converter.getShaderInfo().getType() != ShaderType::ePixel
+    || (ioVar.registerType != RegisterType::eInput && ioVar.registerType != RegisterType::ePixelTexCoord)
+    || ioVar.semantic.usage != SemanticUsage::eTexCoord)
+    return texCoordComponent;
+
+  /* We need to replace TEXCOORD inputs with gl_PointCoord
+   * if D3DRS_POINTSPRITEENABLE is set. */
+
+  ir::SsaDef pointCoord;
+
+  if (componentIndex < 2) // The point coord input is only a vec2
+    pointCoord = builder.add(ir::Op::InputLoad(ir::ScalarType::eF32, m_pointCoord, builder.makeConstant(componentIndex)));
+  else
+    pointCoord = builder.makeConstant(0.0f);
+
+  auto specConstBit = m_converter.m_specConstants.get(builder, SpecConstantId::eSpecPointMode,
+    builder.makeConstant(1u), builder.makeConstant(1u));
+  auto pointSpriteEnabled = builder.add(ir::Op::IEq(ir::ScalarType::eBool, specConstBit, builder.makeConstant(1u)));
+
+  auto texCoordComponentType = builder.getOp(texCoordComponent).getType();
+
+  return builder.add(ir::Op::Select(
+    texCoordComponentType,
+    pointSpriteEnabled,
+    pointCoord,
+    texCoordComponent
+  ));
 }
 
 

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -182,8 +182,6 @@ private:
 
   void dclPointCoord(ir::Builder& builder);
 
-  ir::SsaDef emitPointCoordLoad(ir::Builder& builder, uint32_t componentIndex);
-
   /** Turns a front face boolean into a float. 1.0 for the front face, -1.0 for the back face. */
   ir::SsaDef emitFrontFaceFloat(ir::Builder& builder, ir::SsaDef isFrontFaceDef) const;
 
@@ -199,6 +197,10 @@ private:
 
   /** Determines the appropriate semantic for a given register in shader model 1/2 */
   std::optional<Semantic> determineSemanticForRegister(RegisterType regType, uint32_t regIndex);
+
+  /** Replaces the given texcoord component with a point coord component if the application has set the point sprite spec const.
+   * If the given IoVar has the wrong register type or the wrong semantic, it will just return the given texCoord without change. */
+  ir::SsaDef emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoord, uint32_t componentIndex);
 
   void emitDebugName(
     ir::Builder& builder,

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -200,7 +200,7 @@ private:
 
   /** Replaces the given texcoord component with a point coord component if the application has set the point sprite spec const.
    * If the given IoVar has the wrong register type or the wrong semantic, it will just return the given texCoord without change. */
-  ir::SsaDef emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoord, uint32_t componentIndex);
+  ir::SsaDef emitTexCoordPointSpriteAdjustment(ir::Builder& builder, const IoVarInfo& ioVar, ir::SsaDef texCoord, uint32_t componentIndex) const;
 
   void emitDebugName(
     ir::Builder& builder,


### PR DESCRIPTION
The Eldewrito mod for Halo hits the assert that the first commit fixes.

I checked fxc and it does not let you declare inputs with `POSITION0` as semantic. It allows using `POSITION` with index 1 - 15. It also allows using `SV_POSITION` or `VPOS`, both of which generate the same code:
`dcl_POSITION0 vPos` and that's what the asserts allow.

On top of that, while scrolling through the code, I noticed that the texcoord -> pointcoord replacement for when the game enables point sprites currently only works with shader model 3 pixel shaders because `RegisterType::eInput` is only used for colors on SM1 & SM2 and they have a separate register for texcoords. Shader model 1 works entirely different and uses the `emitTexCoordLoad` function which doesn't do this texcoord replacement step yet.

This PR fixes that. The problem is that I still don't know a game which uses point sprites and relies on this step. All I know is that the old compiler did that.