### PR TITLE
sm3: Fix accidental uint8 indexing.

### DIFF
--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -662,7 +662,7 @@ ir::SsaDef IoMap::emitLoad(
         .addOperand(index));
 
     for (auto c : swizzle.getReadMask(componentMask)) {
-      auto componentIndex = uint8_t(util::componentFromBit(c));
+      auto componentIndex = uint32_t(util::componentFromBit(c));
 
       components[componentIndex] = convertScalar(builder, type, builder.add(
         ir::Op::CompositeExtract(ir::ScalarType::eF32, vec4Value, builder.makeConstant(componentIndex))));
@@ -698,7 +698,7 @@ ir::SsaDef IoMap::emitTexCoordLoad(
   }
 
   for (auto c : swizzle.getReadMask(componentMask)) {
-    auto componentIndex = uint8_t(util::componentFromBit(c));
+    auto componentIndex = uint32_t(util::componentFromBit(c));
 
     if (!ioVar) {
       components[componentIndex] = builder.add(ir::Op::Undef(type));


### PR DESCRIPTION
Verified with some static_asserts that we no longer create u8 constants anywhere except in some internal pass when explicitly requested.