### PR TITLE
Fix SM3 compiler warnings

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -1620,13 +1620,13 @@ bool Converter::handlePow(ir::Builder& builder, const Instruction& op) {
 
   auto dst = op.getDst();
   auto scalarType = dst.isPartialPrecision() ? ir::ScalarType::eMinF16 : ir::ScalarType::eF32;
+
   WriteMask writeMask = dst.getWriteMask(getShaderInfo());
-  Swizzle src0Swizzle = op.getSrc(0u).getSwizzle(getShaderInfo());
-  Swizzle src1Swizzle = op.getSrc(1u).getSwizzle(getShaderInfo());
 
   /* The swizzles must be replicate swizzles. */
-  dxbc_spv_assert(src0Swizzle.x() == src0Swizzle.y() && src0Swizzle.y() == src0Swizzle.z() && src0Swizzle.z() == src0Swizzle.w());
-  dxbc_spv_assert(src1Swizzle.x() == src1Swizzle.y() && src1Swizzle.y() == src1Swizzle.z() && src1Swizzle.z() == src1Swizzle.w());
+  dxbc_spv_assert(op.getSrc(0u).getSwizzle(getShaderInfo()) == Swizzle(op.getSrc(0u).getSwizzle(getShaderInfo()).x()));
+  dxbc_spv_assert(op.getSrc(1u).getSwizzle(getShaderInfo()) == Swizzle(op.getSrc(1u).getSwizzle(getShaderInfo()).x()));
+
   auto src0 = loadSrcModified(builder, op, op.getSrc(0u), ComponentBit::eX, scalarType);
   auto src1 = loadSrcModified(builder, op, op.getSrc(1u), ComponentBit::eX, scalarType);
 

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -1590,19 +1590,18 @@ bool Converter::handleSinCos(ir::Builder& builder, const Instruction& op) {
   /* dst.x = cos(src)
    * dst.y = sin(src)
    * Before PS 3_0, shaders had to provide specific consts as src1 and src2. */
-  uint32_t majorVersion = getShaderInfo().getVersion().first;
-  dxbc_spv_assert((majorVersion >= 3u && op.getSrcCount() == 1u) || op.getSrcCount() == 3u);
+  dxbc_spv_assert(op.getSrcCount() == (getShaderInfo().getVersion().first == 3u ? 1u : 3u));
   dxbc_spv_assert(op.hasDst());
+  dxbc_spv_assert(op.getSrc(0u).getSwizzle(getShaderInfo()) == Swizzle(op.getSrc(0u).getSwizzle(getShaderInfo()).x()));
 
   auto dst = op.getDst();
-  Swizzle swizzle = op.getSrc(0u).getSwizzle(getShaderInfo());
-  dxbc_spv_assert(swizzle.x() == swizzle.y() && swizzle.y() == swizzle.z() && swizzle.z() == swizzle.w());
   WriteMask writeMask = dst.getWriteMask(getShaderInfo());
 
   auto scalarType = dst.isPartialPrecision() ? ir::ScalarType::eMinF16 : ir::ScalarType::eF32;
   auto val = loadSrcModified(builder, op, op.getSrc(0u), ComponentBit::eX, scalarType);
 
   dxbc_spv_assert((writeMask & (ComponentBit::eZ | ComponentBit::eW)) == WriteMask());
+
   util::small_vector<ir::SsaDef, 2u> components = { };
   if (writeMask & ComponentBit::eX)
     components.push_back(builder.add(ir::Op::FCos(scalarType, val)));

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -288,7 +288,8 @@ void IoMap::dclIoVar(
     }
   }
 
-  dxbc_spv_assert(!foundExisting);
+  if (foundExisting)
+    dxbc_spv_assert(!foundExisting);
 
   auto builtIn = determineBuiltinForRegister(registerType, registerIndex, semantic);
 


### PR DESCRIPTION
I still think these should have been runtime checks rather than asserts because we're not exactly robust against borked input, but I guess that ship has sailed.