### PR TITLE
sm3: Add public functions to query fixed-function I/O locations.

### DIFF
--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -9,7 +9,7 @@
 
 namespace dxbc_spv::sm3 {
 
-static std::array<Semantic, 12u> s_ffLocations = {{
+const std::array<Semantic, 12u> IoMap::s_ffLocations = {{
   {SemanticUsage::eNormal,   0u},
   {SemanticUsage::eTexCoord, 0u},
   {SemanticUsage::eTexCoord, 1u},
@@ -996,6 +996,16 @@ void IoMap::emitClipPlaneStore(ir::Builder& builder, uint32_t index, ir::SsaDef 
   dxbc_spv_assert(index < MaxClipPlanes);
 
   builder.add(ir::Op::OutputStore(m_clipDistances, builder.makeConstant(index), value));
+}
+
+
+std::optional<uint32_t> IoMap::findFixedFunctionLocation(Semantic semantic) {
+  for (uint32_t i = 0u; i < s_ffLocations.size(); i++) {
+    if (s_ffLocations[i] == semantic)
+      return std::make_optional(i);
+  }
+
+  return std::nullopt;
 }
 
 

--- a/sm3/sm3_io_map.h
+++ b/sm3/sm3_io_map.h
@@ -141,6 +141,14 @@ public:
 
   void emitClipPlaneStore(ir::Builder& builder, uint32_t index, ir::SsaDef value);
 
+  /** Looks up fixed-function I/O variable location by semantic */
+  static std::optional<uint32_t> findFixedFunctionLocation(Semantic semantic);
+
+  /** Total number of reserved fixed-function I/O locations */
+  static uint32_t getFixedFunctionLocationCount() {
+    return uint32_t(s_ffLocations.size());
+  }
+
 private:
 
   Converter&      m_converter;
@@ -158,6 +166,8 @@ private:
 
   ir::SsaDef emitDynamicLoadFunction(ir::Builder& builder) const;
   ir::SsaDef emitDynamicStoreFunction(ir::Builder& builder) const;
+
+  static const std::array<Semantic, 12u> s_ffLocations;
 
   void emitIoVarDefault(
           ir::Builder& builder,


### PR DESCRIPTION
To avoid some duplication. DXVK needs to know FF locations in the d3d9 pre-pass *and* SWVP.