### PR TITLE
misc. SM3 stuff

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -2208,34 +2208,25 @@ void Converter::emitAlphaTest(ir::Builder& builder) {
   /* Perform comparison and return result */
   auto switchDef = builder.add(ir::Op::ScopedSwitch(ir::SsaDef(), alphaComparisonMode));
 
-  for (uint32_t i = 0u; i < uint32_t(AlphaTestComparisonMode::eAlways); i++) {
-    builder.add(ir::Op::ScopedSwitchCase(switchDef, i));
+  static const std::array<std::pair<AlphaTestComparisonMode, ir::OpCode>, 6u> s_ops = {{
+    { AlphaTestComparisonMode::eLess,           ir::OpCode::eFLt },
+    { AlphaTestComparisonMode::eEqual,          ir::OpCode::eFEq },
+    { AlphaTestComparisonMode::eLessOrEqual,    ir::OpCode::eFLe },
+    { AlphaTestComparisonMode::eGreater,        ir::OpCode::eFGt },
+    { AlphaTestComparisonMode::eNotEqual,       ir::OpCode::eFNe },
+    { AlphaTestComparisonMode::eGreaterOrEqual, ir::OpCode::eFGe },
+  }};
 
-    ir::Op comparisonOp = {};
-
-    switch (AlphaTestComparisonMode(i)) {
-      case AlphaTestComparisonMode::eNever:
-        comparisonOp = ir::Op::Constant(false); break;
-      case AlphaTestComparisonMode::eLess:
-        comparisonOp = ir::Op::FLt(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eEqual:
-        comparisonOp = ir::Op::FEq(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eLessOrEqual:
-        comparisonOp = ir::Op::FLe(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eGreater:
-        comparisonOp = ir::Op::FGt(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eNotEqual:
-        comparisonOp = ir::Op::FNe(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eGreaterOrEqual:
-        comparisonOp = ir::Op::FGe(ir::ScalarType::eBool, alpha, alphaRef); break;
-      case AlphaTestComparisonMode::eAlways:
-        comparisonOp = ir::Op::Constant(true); break;
-      default:
-        dxbc_spv_unreachable();
-    }
-    auto comparisonBool = builder.add(comparisonOp);
-    builder.add(ir::Op::Return(ir::ScalarType::eBool, comparisonBool));
+  for (const auto& op : s_ops) {
+    builder.add(ir::Op::ScopedSwitchCase(switchDef, uint32_t(op.first)));
+    builder.add(ir::Op::Return(ir::ScalarType::eBool, builder.add(
+      ir::Op(op.second, ir::ScalarType::eBool).addOperands(alpha, alphaRef))));
   }
+
+  /* AlphaTestComparisonMode::eNever. We already handled eAlways. */
+  builder.add(ir::Op::ScopedSwitchDefault(switchDef));
+  builder.add(ir::Op::Return(ir::ScalarType::eBool, builder.makeConstant(false)));
+
   auto switchEnd = builder.add(ir::Op::ScopedEndSwitch(switchDef));
   builder.rewriteOp(switchDef, ir::Op(builder.getOp(switchDef)).setOperand(0u, switchEnd));
 

--- a/sm3/sm3_io_map.cpp
+++ b/sm3/sm3_io_map.cpp
@@ -195,10 +195,8 @@ std::optional<ir::BuiltIn> IoMap::determineBuiltinForRegister(RegisterType regTy
   auto shaderInfo = m_converter.getShaderInfo();
 
   if (!registerTypeIsInput(regType, shaderInfo.getType())) {
-
-    if (regType == RegisterType::eDepthOut) {
+    if (regType == RegisterType::eDepthOut)
       return std::make_optional(ir::BuiltIn::eDepth);
-    }
 
     if (regType == RegisterType::eRasterizerOut) {
       if (regIndex == uint32_t(RasterizerOutIndex::eRasterOutPointSize)) {
@@ -222,7 +220,6 @@ std::optional<ir::BuiltIn> IoMap::determineBuiltinForRegister(RegisterType regTy
 
     /* The dcl instructions with a semantic only exist in SM3
      * and SM3 uses generic output registers. */
-
     if (semantic.usage == SemanticUsage::ePosition && semantic.index == 0u) {
       dxbc_spv_assert(regType == RegisterType::eOutput);
       return std::make_optional(ir::BuiltIn::ePosition);
@@ -234,29 +231,20 @@ std::optional<ir::BuiltIn> IoMap::determineBuiltinForRegister(RegisterType regTy
     }
 
     return std::nullopt;
-
   } else {
-
-    /* Position 0 must not be mapped to a regular input. SM3 still has a separate register for that. */
-    dxbc_spv_assert(shaderInfo.getType() == ShaderType::eVertex
-      || semantic.usage != SemanticUsage::ePosition
-      || semantic.index != 0u
-      || regType != RegisterType::eInput);
-
     if (regType == RegisterType::eMiscType) {
-      if (regIndex == uint32_t(MiscTypeIndex(MiscTypeIndex::eMiscTypeFace))) {
-        return std::make_optional(ir::BuiltIn::eIsFrontFace);
-      }
+      switch (regIndex) {
+        case uint32_t(MiscTypeIndex(MiscTypeIndex::eMiscTypeFace)):
+          return std::make_optional(ir::BuiltIn::eIsFrontFace);
 
-      if (regIndex == uint32_t(MiscTypeIndex::eMiscTypePosition)) {
-        dxbc_spv_assert(semantic.usage == SemanticUsage::ePosition && semantic.index == 0u);
-        return std::make_optional(ir::BuiltIn::ePosition);
-      }
+        /* SM3 special input register for PS position */
+        case uint32_t(MiscTypeIndex::eMiscTypePosition):
+          return std::make_optional(ir::BuiltIn::ePosition);
 
-      /* Invalid MiscType */
-      dxbc_spv_assert(false);
+        default:
+          dxbc_spv_unreachable();
+      }
     }
-
   }
 
   return std::nullopt;

--- a/tools/dxbc_disasm.cpp
+++ b/tools/dxbc_disasm.cpp
@@ -108,9 +108,13 @@ bool printCodeSM3(util::ByteReader reader, bool useDebugNames) {
 
   while (parser) {
     auto op = parser.parseInstruction();
-    if (useDebugNames && op.getOpCode() == sm3::OpCode::eComment && !ctab) {
-      auto ctabReader = util::ByteReader(op.getCommentData(), op.getCommentDataSize());
-      ctab = sm3::ConstantTable(ctabReader);
+    if (op.getOpCode() == sm3::OpCode::eComment) {
+      if (useDebugNames && !ctab) {
+        auto ctabReader = util::ByteReader(op.getCommentData(), op.getCommentDataSize());
+        ctab = sm3::ConstantTable(ctabReader);
+      }
+
+      continue;
     }
 
     if (!op) {


### PR DESCRIPTION
Splinter Cell 4 asserts because vpos has `POSITIONT` semantics rather than `POSITION`, so... probably just ignore it.

The disassembler was spamming newlines left and right with Shader Model 1 stuff due to comments.