### PR TITLE
sm3: Implement function calls.

### DIFF
--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -239,7 +239,7 @@ bool Converter::convertInstruction(ir::Builder& builder, const Instruction& op) 
       return handleCall(builder, op);
 
     case OpCode::eRet:
-      return logOpError(op, "Function calls aren't supported.");
+      return handleRet(builder);
   }
 
   return logOpError(op, "Unhandled opcode.");
@@ -250,7 +250,6 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
   /* A valid debug namee is required for the main function */
   m_entryPoint.mainFunc = builder.add(ir::Op::Function(ir::ScalarType::eVoid));
   builder.add(ir::Op::FunctionEnd());
-  builder.add(ir::Op::DebugName(m_entryPoint.mainFunc, "main"));
 
   /* Emit entry point instruction as the first instruction of the
    * shader. This is technically not needed, but makes things more
@@ -299,6 +298,28 @@ bool Converter::initialize(ir::Builder& builder, ShaderType shaderType) {
 
 
 bool Converter::finalize(ir::Builder& builder, ShaderType shaderType) {
+  if (m_entryPoint.needsWrapper) {
+    // Adjust current 'main' function
+    auto wrapped = m_entryPoint.mainFunc;
+    builder.add(ir::Op::DebugName(wrapped, "main_wrapped"));
+    builder.setCursor(ir::SsaDef());
+
+    // Emit wrapper function that calls the main entry point first
+    auto wrapper = builder.add(ir::Op::Function(ir::ScalarType::eVoid));
+    auto call = builder.add(ir::Op::FunctionCall(ir::ScalarType::eVoid, wrapped));
+    builder.add(ir::Op::FunctionEnd());
+
+    // Rewrite entry point to point to the 'new' main function
+    builder.rewriteOp(m_entryPoint.def, ir::Op(builder.getOp(m_entryPoint.def)).setOperand(0u, wrapper));
+    m_entryPoint.mainFunc = wrapper;
+
+    // Put all the finalization code after the wrapper call
+    builder.setCursor(call);
+  }
+
+  // Emit debug name for the actual entry point function
+  builder.add(ir::Op::DebugName(m_entryPoint.mainFunc, "main"));
+
   if (shaderType == ShaderType::ePixel && getShaderInfo().getVersion().first == 1u) {
     /* Shader model 1 doesn't have special color output registers.
      * Instead, it simply outputs what was in Temp register 0 (r0) at the end. */
@@ -360,7 +381,6 @@ bool Converter::finalize(ir::Builder& builder, ShaderType shaderType) {
   }
 
   m_ioMap.finalize(builder);
-
   return true;
 }
 
@@ -1952,6 +1972,16 @@ bool Converter::handleCall(ir::Builder& builder, const Instruction& op) {
       builder.add(ir::Op::ScopedEndIf(ifCall))));
   }
 
+  return true;
+}
+
+
+bool Converter::handleRet(ir::Builder& builder) {
+  // Need to wrap the main function so that we have a valid
+  // place to put all the output stores and processing.
+  m_entryPoint.needsWrapper = true;
+
+  builder.add(ir::Op::Return());
   return true;
 }
 

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -232,6 +232,8 @@ bool Converter::convertInstruction(ir::Builder& builder, const Instruction& op) 
       return handleEndRep(builder, op);
 
     case OpCode::eLabel:
+      return handleLabel(builder, op);
+
     case OpCode::eCall:
     case OpCode::eCallNz:
     case OpCode::eRet:
@@ -1907,6 +1909,15 @@ bool Converter::handleEndRep(ir::Builder &builder, const Instruction &op) {
   builder.rewriteOp(construct->def, ir::Op(builder.getOp(construct->def)).setOperand(0u, constructEnd));
 
   m_controlFlow.pop();
+  return true;
+}
+
+
+bool Converter::handleLabel(ir::Builder& builder, const Instruction& op) {
+  if (!op.hasDst() || op.getDst().getRegisterType() != RegisterType::eLabel)
+    return logOpError(op, "'Label' operand missing or not a label");
+
+  builder.setCursor(m_regFile.getOrDeclareLabel(builder, op.getDst()));
   return true;
 }
 

--- a/sm3/sm3_converter.cpp
+++ b/sm3/sm3_converter.cpp
@@ -236,6 +236,8 @@ bool Converter::convertInstruction(ir::Builder& builder, const Instruction& op) 
 
     case OpCode::eCall:
     case OpCode::eCallNz:
+      return handleCall(builder, op);
+
     case OpCode::eRet:
       return logOpError(op, "Function calls aren't supported.");
   }
@@ -1918,6 +1920,38 @@ bool Converter::handleLabel(ir::Builder& builder, const Instruction& op) {
     return logOpError(op, "'Label' operand missing or not a label");
 
   builder.setCursor(m_regFile.getOrDeclareLabel(builder, op.getDst()));
+  return true;
+}
+
+
+bool Converter::handleCall(ir::Builder& builder, const Instruction& op) {
+  const auto& target = op.getSrc(0u);
+
+  if (!target || target.getRegisterType() != RegisterType::eLabel)
+    return logOpError(op, "'Call' label missing or not a label");
+
+  auto fn = m_regFile.getOrDeclareLabel(builder, target);
+  auto ifCall = ir::SsaDef();
+
+  if (op.getOpCode() == OpCode::eCallNz) {
+    auto condReg = op.getSrc(1u);
+    auto cond = loadSrc(builder, op, condReg, ComponentBit::eX, condReg.getSwizzle(getShaderInfo()), ir::ScalarType::eBool);
+
+    if (condReg.getModifier() == OperandModifier::eNot)
+      cond = builder.add(ir::Op::BNot(ir::ScalarType::eBool, cond));
+    else if (condReg.getModifier() != OperandModifier::eNone)
+      return logOpError(op, "Unknown callnz condition modifier: ", uint32_t(condReg.getModifier()));
+
+    ifCall = builder.add(ir::Op::ScopedIf(ir::SsaDef(), cond));
+  }
+
+  builder.add(ir::Op::FunctionCall(ir::ScalarType::eVoid, fn));
+
+  if (ifCall) {
+    builder.rewriteOp(ifCall, ir::Op(builder.getOp(ifCall)).setOperand(0u,
+      builder.add(ir::Op::ScopedEndIf(ifCall))));
+  }
+
   return true;
 }
 

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -210,6 +210,8 @@ private:
 
   bool handleEndRep(ir::Builder& builder, const Instruction& op);
 
+  bool handleLabel(ir::Builder& builder, const Instruction& op);
+
   ir::SsaDef loadSrc(ir::Builder& builder, const Instruction& op, const Operand& operand, WriteMask mask, Swizzle swizzle, ir::ScalarType type);
 
   ir::SsaDef applySrcModifiers(ir::Builder& builder, ir::SsaDef def, const Instruction& instruction, const Operand& operand, WriteMask mask);

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -212,6 +212,8 @@ private:
 
   bool handleLabel(ir::Builder& builder, const Instruction& op);
 
+  bool handleCall(ir::Builder& builder, const Instruction& op);
+
   ir::SsaDef loadSrc(ir::Builder& builder, const Instruction& op, const Operand& operand, WriteMask mask, Swizzle swizzle, ir::ScalarType type);
 
   ir::SsaDef applySrcModifiers(ir::Builder& builder, ir::SsaDef def, const Instruction& instruction, const Operand& operand, WriteMask mask);

--- a/sm3/sm3_converter.h
+++ b/sm3/sm3_converter.h
@@ -81,9 +81,9 @@ private:
 
   /* Entry point definition and function definitions. */
   struct {
-    ir::SsaDef def;
-
-    ir::SsaDef mainFunc;
+    ir::SsaDef def {};
+    ir::SsaDef mainFunc = {};
+    bool needsWrapper = false;
   } m_entryPoint;
 
   bool convertInstruction(ir::Builder& builder, const Instruction& op);
@@ -213,6 +213,8 @@ private:
   bool handleLabel(ir::Builder& builder, const Instruction& op);
 
   bool handleCall(ir::Builder& builder, const Instruction& op);
+
+  bool handleRet(ir::Builder& builder);
 
   ir::SsaDef loadSrc(ir::Builder& builder, const Instruction& op, const Operand& operand, WriteMask mask, Swizzle swizzle, ir::ScalarType type);
 

--- a/sm3/sm3_registers.cpp
+++ b/sm3/sm3_registers.cpp
@@ -280,4 +280,31 @@ void RegisterFile::emitBufferedStores(ir::Builder& builder) {
   m_stores.clear();
 }
 
+
+ir::SsaDef RegisterFile::getOrDeclareLabel(
+        ir::Builder&            builder,
+  const Operand&                operand) {
+  dxbc_spv_assert(operand.getRegisterType() == RegisterType::eLabel);
+
+  auto index = operand.getIndex();
+
+  if (index >= m_labels.size())
+    m_labels.resize(index + 1u);
+
+  auto& fn = m_labels[index];
+
+  if (!fn) {
+    /* Declare function right after declaration section and begin/end
+     * it immediately. We will move the cursor once the corresponding
+     * label instruction is encountered. */
+    auto ref = builder.getCode().first->getDef();
+
+    fn = builder.addBefore(ref, ir::Op::Function(ir::ScalarType::eVoid));
+    builder.addAfter(fn, ir::Op::FunctionEnd());
+    builder.add(ir::Op::DebugName(fn, (std::string("l") + std::to_string(index)).c_str()));
+  }
+
+  return fn;
+}
+
 }

--- a/sm3/sm3_registers.h
+++ b/sm3/sm3_registers.h
@@ -61,6 +61,11 @@ public:
           WriteMask               componentMask,
           ir::ScalarType          type);
 
+  /** Retrieves or declares label as function */
+  ir::SsaDef getOrDeclareLabel(
+          ir::Builder&            builder,
+    const Operand&                operand);
+
 private:
 
   ir::SsaDef getOrDeclareTemp(ir::Builder& builder, uint32_t index, Component component);
@@ -94,6 +99,9 @@ private:
 
   /* In shader model 1.1 - 1.3, you put either texture data (from sampling) or texcoords into a texture register. */
   std::array<ir::SsaDef, 8u * 4u> m_textureRegs = { };
+
+  /** Label functions */
+  util::small_vector<ir::SsaDef, 8u> m_labels = { };
 
 };
 


### PR DESCRIPTION
Can only really be produced with hand-written assembly (which in turn can only be compiled via vsa/psa.exe from the 2008 DirectX SDK), but might as well be feature-complete.

Implementation is somewhat trivial, besides `ret` because we have to assume that that instruction can occur inside control flow.