### PR TITLE
sm3: Change how swizzles are printed in disasm.

### DIFF
--- a/sm3/sm3_disasm.cpp
+++ b/sm3/sm3_disasm.cpp
@@ -230,20 +230,20 @@ void Disassembler::disassembleOperand(std::ostream& stream, const Instruction& o
 
   stream << UnambiguousRegisterType { arg.getRegisterType(), m_info.getType(), m_info.getVersion().first };
   disassembleRegisterAddressing(stream, arg, ctab);
-  disassembleSwizzleWriteMask(stream, op, arg);
+  disassembleSwizzleWriteMask(stream, arg);
 
   if (arg.getInfo().kind == OperandKind::eSrcReg
     && (modifier == OperandModifier::eDz || modifier == OperandModifier::eDw)) {
     stream << " / ";
     stream << UnambiguousRegisterType { arg.getRegisterType(), m_info.getType(), m_info.getVersion().first };
     disassembleRegisterAddressing(stream, arg, ctab);
-    disassembleSwizzleWriteMask(stream, op, arg);
+    disassembleSwizzleWriteMask(stream, arg);
   }
 
   stream << suffix;
 }
 
-void Disassembler::disassembleSwizzleWriteMask(std::ostream& stream, const Instruction& op, const Operand& arg) const {
+void Disassembler::disassembleSwizzleWriteMask(std::ostream& stream, const Operand& arg) const {
   switch (arg.getSelectionMode(m_info)) {
     case SelectionMode::eMask:
       if (arg.getWriteMask(m_info) != WriteMask(ComponentBit::eAll))
@@ -251,15 +251,15 @@ void Disassembler::disassembleSwizzleWriteMask(std::ostream& stream, const Instr
       break;
     case SelectionMode::eSwizzle: {
       Swizzle swizzle = arg.getSwizzle(m_info);
-      WriteMask dstWriteMask = op.hasDst() ? op.getDst().getWriteMask(m_info) : WriteMask(ComponentBit::eAll);
 
       if (swizzle != Swizzle::identity()) {
-        /* Only print the components that are relevant according to the write mask. */
         stream << ".";
-        for (uint32_t i = 0u; i < 4u; i++) {
-          if (dstWriteMask & WriteMask(ComponentBit(1u << i))) {
-            stream << swizzle.get(i);
-          }
+
+        /* If all components are the same, just print it once. */
+        bool swizzleRepetitive = swizzle == Swizzle(swizzle.x());
+
+        for (uint32_t i = 0u; i < (swizzleRepetitive ? 1u : 4u); i++) {
+          stream << swizzle.get(i);
         }
       }
     } break;

--- a/sm3/sm3_disasm.h
+++ b/sm3/sm3_disasm.h
@@ -45,7 +45,7 @@ private:
 
   void disassembleRegisterAddressing(std::ostream& stream, const Operand& arg, const ConstantTable& ctab) const;
 
-  void disassembleSwizzleWriteMask(std::ostream& stream, const Instruction& op, const Operand& arg) const;
+  void disassembleSwizzleWriteMask(std::ostream& stream, const Operand& arg) const;
 
   void emitLineNumber(std::ostream& stream);
 


### PR DESCRIPTION
The way we currently disassemble swizzles applies the write mask which is confusing for texcoords and other things.

>     47:     texld r0.w, v0.y, s5.x

So don't do that: 

>     47:     texld r0.w, v0.xyyy, s5.xxxx

Instead, don't repeat swizzles that just repeat one component for 4 indices:

>     47:     texld r0.w, v0.xyyy, s5.x

So instead of trying to be clever with the write mask, we just don't print identity swizzles and simplify those that just repeat one component.