### PR TITLE
sm3: don't reject parameter tokens with bit 31 clear

### DIFF
--- a/sm3/sm3_parser.cpp
+++ b/sm3/sm3_parser.cpp
@@ -490,12 +490,12 @@ Operand::Operand(util::ByteReader& reader, const OperandInfo& info, Instruction&
     }
   }
 
-  if ((info.kind == OperandKind::eDstReg || info.kind == OperandKind::eSrcReg)
-    && !util::bextract(m_token, 31u, 1u)) {
-    Logger::err("Token is not an operand.");
-    resetOnError();
-    return;
-  }
+  /* Do not reject register operands whose bit 31 is clear. Bit 31 is not a
+   * reliable operand marker: real D3D9 bytecode leaves it clear on destination
+   * and dcl register tokens, and neither the D3D9 runtime, the legacy dxso
+   * decoder nor wined3d inspect it. Operand counts come from the instruction
+   * length field / layout table and are bounded by the token sub-range, so no
+   * such check is needed (or correct) here. */
 
   if ((info.kind == OperandKind::eDstReg || info.kind == OperandKind::eSrcReg) && hasRelativeAddressing()) {
     RegisterType registerType = getRegisterType();


### PR DESCRIPTION
## Problem

The SM3 parser fails to parse essentially every Direct3D 9 shader emitted by the Source engine (Counter-Strike: Source / Global Offensive, etc.). When used from DXVK's d3d9 frontend, shader creation fails in `D3D9DeviceEx::CreateShaderModule` with:

```
err: Token is not an operand.
err: Failed to read operand.
err:   CreateShaderModule: Shader analysis prepass failed
```

## Root cause

`sm3::Operand`'s constructor rejects any destination or source register token whose bit 31 (`0x80000000`) is clear:

```cpp
if ((info.kind == OperandKind::eDstReg || info.kind == OperandKind::eSrcReg)
    && !util::bextract(m_token, 31u, 1u)) {
  Logger::err("Token is not an operand.");
  ...
}
```

In real D3D9 bytecode, however, **only source operand tokens set bit 31**; **destination and `dcl` register tokens legitimately leave it clear.**

Here is a captured `vs_2_0` shader that fails (the token stream is representative of the whole class). The very first instruction is a `dcl`, and its register token is rejected:

```
0xFFFE0200   vs_2_0
0x0200001F   dcl                    (opcode 0x1f, length 2)
0x80000000     usage token (POSITION)          bit31 = 1
0x100F0000     v0 (declared register)          bit31 = 0   <-- rejected here
0x0200001F   dcl ...  (v1)
0x0200001F   dcl ...  (v2)
0x03000009   dp4                    (length 3)
0x40010000     oPos.x  (dst)                    bit31 = 0
0x90E40000     v0      (src)                    bit31 = 1
0xA0E40000     c0      (src)                    bit31 = 1
...            (3 more dp4 writing oPos.yzw, 2 mov)
0x0000FFFF   end
```

The parser reads `0x100F0000` as the `dcl` register operand (`eDstReg`), sees bit 31 clear and aborts, so the shader is rejected at instruction 0.

## Why bit 31 must not be validated

Bit 31 is not a reliable "is an operand" marker and is not enforced by the D3D9 runtime. Neither DXVK's own legacy `dxso` decoder nor wined3d's `shader_sm1.c` ever inspects it — they decode register tokens purely from the register number (bits 0-10), type (bits 11-12 | 28-30), relative-addressing bit (13) and write-mask/swizzle (bits 16-23).

The check is also structurally unnecessary here: operand counts come from the SM2+ instruction-length field (`bextract(m_token, 24, 4)`) or the SM1 layout table, and each instruction's operands are read from a token sub-range sized to exactly that count (with a trailing `getRemaining() == 0` assertion). Removing the check therefore cannot introduce operand desync.

## Fix

Remove the bit-31 rejection for register operands. The register-type, index and relative-addressing validations that follow are unaffected. With this change, Source-engine D3D9 shaders parse and render correctly (verified against DXVK 3.0.1 + the d3d9 frontend; behaviour now matches DXVK 2.7.x).

## Note (not changed here)

The predicate-token path a few lines below carries the same bit-31 assumption (`"Predicate token is not an operand."`). I left it untouched: it was not exercised by the shaders I tested and predicate tokens do appear to set bit 31 in practice. Happy to fold in a consistent change if you'd prefer.
