### PR TITLE
util: Explicitly include new in util_small_vector.h

### DIFF
--- a/util/util_small_vector.h
+++ b/util/util_small_vector.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <new>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
Fixes compilation with libc++ 23, which no longer includes it implicitly.