### PR TITLE
dxbc: Fix UDiv and UMod by zero

### DIFF
--- a/dxbc/dxbc_converter.cpp
+++ b/dxbc/dxbc_converter.cpp
@@ -1479,6 +1479,7 @@ bool Converter::handleIntDivide(ir::Builder& builder, const Instruction& op) {
   /* Process division one component at a time */
   auto zero = makeTypedConstant(builder, scalarType,  0u);
   auto neg1 = makeTypedConstant(builder, scalarType, -1u);
+  auto one  = makeTypedConstant(builder, scalarType,  1u);
 
   util::small_vector<ir::SsaDef, 4u> divScalars;
   util::small_vector<ir::SsaDef, 4u> modScalars;
@@ -1489,15 +1490,20 @@ bool Converter::handleIntDivide(ir::Builder& builder, const Instruction& op) {
 
     auto cond = builder.add(ir::Op::INe(ir::ScalarType::eBool, den, zero));
 
+    /* UDiv and UMod by zero is undefined behavior. This allows compilers to remove
+     * the select guard since it can be assumed den is never zero. To prevent this
+     * use a safe divisor to ensure the compiler won't optimize away the select */
+    auto safeDen = builder.add(ir::Op::Select(scalarType, cond, den, one));
+
     if (dstDiv.getWriteMask() & c) {
       auto& scalar = divScalars.emplace_back();
-      scalar = builder.add(ir::Op::UDiv(scalarType, num, den));
+      scalar = builder.add(ir::Op::UDiv(scalarType, num, safeDen));
       scalar = builder.add(ir::Op::Select(scalarType, cond, scalar, neg1));
     }
 
     if (dstMod.getWriteMask() & c) {
       auto& scalar = modScalars.emplace_back();
-      scalar = builder.add(ir::Op::UMod(scalarType, num, den));
+      scalar = builder.add(ir::Op::UMod(scalarType, num, safeDen));
       scalar = builder.add(ir::Op::Select(scalarType, cond, scalar, neg1));
     }
   }


### PR DESCRIPTION
From the SPIR-V spec OpUDiv and OpUMod by zero is undefined behavior. This allows compilers to assume the operand used as the divisor is always a non-zero value.

This change updates handleIntDivide to provide a safe divisor to the UDiv and UMod operations. This ensures the select is always kept since the compiler can no longer assume den is always a non-zero value.

I confirmed the fix resolves the Ghost Recon Breakpoint issue by manually editing the SPIR-V in renderdoc to use the safe divisor path.

Fixes: https://github.com/doitsujin/dxvk/issues/5849